### PR TITLE
[WIP] Use web mercator tiles from the new helsinki tile pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
     "moment": "^2.15.2",
     "normalize.css": "^5.0.0",
     "normalizr": "^2.2.1",
-    "proj4": "^2.3.14",
-    "proj4leaflet": "^1.0.1",
     "react": "^15.4.1",
     "react-bootstrap": "^0.30.6",
     "react-dom": "^15.4.1",

--- a/src/modules/map/constants.js
+++ b/src/modules/map/constants.js
@@ -1,6 +1,6 @@
 import {normalizeActionName} from '../common/helpers.js';
 
-export const MAP_URL = 'http://tiles.hel.ninja/styles/hel-osm-light/{z}/{x}/{y}.png';
+export const MAP_URL = 'https://tiles.hel.ninja/styles/hel-osm-light/{z}/{x}/{y}.png';
 export const MAP_RETINA_URL = MAP_URL.replace('.png','@2x.png');
 
 export const DEFAULT_ZOOM = 12;

--- a/src/modules/map/constants.js
+++ b/src/modules/map/constants.js
@@ -1,9 +1,9 @@
 import {normalizeActionName} from '../common/helpers.js';
 
-export const MAP_URL = 'https://geoserver.hel.fi/mapproxy/wmts/osm-lite/etrs_tm35fin/{z}/{x}/{y}.png';
-export const MAP_RETINA_URL = 'https://geoserver.hel.fi/mapproxy/wmts/osm-lite-hq/etrs_tm35fin_hq/{z}/{x}/{y}.png';
+export const MAP_URL = 'http://tiles.hel.ninja/styles/hel-osm-light/{z}/{x}/{y}.png';
+export const MAP_RETINA_URL = MAP_URL.replace('.png','@2x.png');
 
-export const DEFAULT_ZOOM = 9;
+export const DEFAULT_ZOOM = 12;
 export const MIN_ZOOM = 8;
 export const MAX_ZOOM = 15;
 export const BOUNDARIES = [[59.4, 23.8], [61.5, 25.8]];

--- a/src/modules/map/constants.js
+++ b/src/modules/map/constants.js
@@ -4,8 +4,8 @@ export const MAP_URL = 'https://tiles.hel.ninja/styles/hel-osm-light/{z}/{x}/{y}
 export const MAP_RETINA_URL = MAP_URL.replace('.png','@2x.png');
 
 export const DEFAULT_ZOOM = 12;
-export const MIN_ZOOM = 8;
-export const MAX_ZOOM = 15;
+export const MIN_ZOOM = 11;
+export const MAX_ZOOM = 18;
 export const BOUNDARIES = [[59.4, 23.8], [61.5, 25.8]];
 
 export const mapActions = {

--- a/src/modules/unit/components/MapView.js
+++ b/src/modules/unit/components/MapView.js
@@ -22,7 +22,12 @@ L.proj = require('proj4leaflet');
 
 const bounds = L.bounds(L.point(-548576, 6291456), L.point(1548576, 8388608));
 const originNw = [bounds.min.x, bounds.max.y];
-const TM35CRS = new L.Proj.CRS(
+
+// current tilesource does not need a CRS, however this is kept as
+// reference for now. Web mercator tilesource might represent some
+// very northern areas with considerable distortions. Visual comparison
+// at Rovaniemi did not show any discernable differences though...
+const TM35CRS = new L.Proj.CRS( //eslint-disable-line
   'EPSG:3067',
   '+proj=utm +zone=35 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs', {
     resolutions: [8192, 4096, 2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.25, 0.125],
@@ -134,7 +139,8 @@ class MapView extends Component {
     return (
       <View id="map-view" className="map-view" isSelected={selected}>
         <Map ref="map"
-          crs={TM35CRS}
+          // Non web mercator tilesources will need as crs
+          // crs={TM35CRS}
           zoomControl={false}
           attributionControl={false}
           center={position}

--- a/src/modules/unit/components/MapView.js
+++ b/src/modules/unit/components/MapView.js
@@ -17,23 +17,6 @@ import UserLocationMarker from '../../map/components/UserLocationMarker';
 import {translate} from 'react-i18next';
 import {isRetina} from '../../common/helpers';
 
-let L = require('leaflet');
-L.proj = require('proj4leaflet');
-
-const bounds = L.bounds(L.point(-548576, 6291456), L.point(1548576, 8388608));
-const originNw = [bounds.min.x, bounds.max.y];
-
-// current tilesource does not need a CRS, however this is kept as
-// reference for now. Web mercator tilesource might represent some
-// very northern areas with considerable distortions. Visual comparison
-// at Rovaniemi did not show any discernable differences though...
-const TM35CRS = new L.Proj.CRS( //eslint-disable-line
-  'EPSG:3067',
-  '+proj=utm +zone=35 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs', {
-    resolutions: [8192, 4096, 2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.25, 0.125],
-    bounds, transformation: new L.Transformation(1, -originNw[0], -1, originNw[1]),
-  });
-
 class MapView extends Component {
   static propTypes = {
     position: PropTypes.array.isRequired,
@@ -139,8 +122,6 @@ class MapView extends Component {
     return (
       <View id="map-view" className="map-view" isSelected={selected}>
         <Map ref="map"
-          // Non web mercator tilesources will need as crs
-          // crs={TM35CRS}
           zoomControl={false}
           attributionControl={false}
           center={position}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4001,10 +4001,6 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-mgrs@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/mgrs/-/mgrs-1.0.0.tgz#fb91588e78c90025672395cb40b25f7cd6ad1829"
-
 micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -4913,19 +4909,6 @@ process@~0.5.1:
 progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
-
-proj4@^2.3.14:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/proj4/-/proj4-2.4.3.tgz#f3bb7e631bffc047c36a1a3cc14533a03bbe9969"
-  dependencies:
-    mgrs "1.0.0"
-    wkt-parser "^1.1.3"
-
-proj4leaflet@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/proj4leaflet/-/proj4leaflet-1.0.1.tgz#965484904473045dc69581a19e94c964047d97e7"
-  dependencies:
-    proj4 "^2.3.14"
 
 promise@^7.1.1:
   version "7.1.1"
@@ -6416,10 +6399,6 @@ window-size@0.1.0:
 window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
-
-wkt-parser@^1.1.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/wkt-parser/-/wkt-parser-1.2.0.tgz#6d09f8bebffb34f122201d99c1d8381c994acb0e"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Notes:
new tile pipeline might still be have some issues with caching. This cannot yet be used in production. Still, ulkoliikunta.fi is a good candidate for initial deployment.

Questions:
* this keeps the CRS definitions in the code and comments out the settings of the CRS. Is that appropriate? Or should the information retained in git history?
* If the CRS is kept in code, I'd like to have it defined in the same place as the tilesource, given that they are intricately linked. Good?
* Is there some way to pass the CRS prop to Map only if it is defined? Of course, a viable workaround would be to define a web mercator CRS, but that seems silly.

All these apply to all of our projects. Do we want to keep at least vestigial support for alternate projections, if we move to a web mercator based tile pipeline?

Benefits:
* lack of rendering errors in tiles
* generally better looking tiles, several style bugs have been fixed
* as side effect: no CRS transformations are needed, as the new tiles use the standard web mercator projection

Of course the "better looking" is always subjective.

Before:
<img width="1046" alt="Näyttökuva 2019-6-7 kello 10 07 20" src="https://user-images.githubusercontent.com/1506787/59087471-5b3fd180-890d-11e9-8f8f-e8c454bc6eae.png">

After:
<img width="935" alt="Näyttökuva 2019-6-7 kello 10 07 29" src="https://user-images.githubusercontent.com/1506787/59087481-6430a300-890d-11e9-95ae-48cfd0090bbc.png">

Also filed as KUVA-149.