### PR TITLE
KUVA-153: Add lost reittiopas and additional info links to place information

### DIFF
--- a/src/modules/unit/components/SingleUnitModalContainer.js
+++ b/src/modules/unit/components/SingleUnitModalContainer.js
@@ -130,17 +130,13 @@ const LocationTemperature = ({t, observation}) => {
   );
 };
 
-const ModalBodyBox = ({title, children, className, ...rest}) =>
-  <div className={`${className || ''} modal-body-box`} {...rest}>
+const ModalBodyBox = ({title, children, className = '', ...rest}) =>
+  <div className={`${className} modal-body-box`} {...rest}>
     {title && <div className="modal-body-box-headline">{title}</div>}
     {children}
   </div>;
 
 export class SingleUnitModalContainer extends Component {
-
-  constructor(props) {
-    super(props);
-  }
 
   shouldShowInfo(unit) {
     const hasExtensions = unit.extensions && (unit.extensions.length || unit.extensions.lighting || unit.extensions.skiing_technique);

--- a/src/modules/unit/components/SingleUnitModalContainer.js
+++ b/src/modules/unit/components/SingleUnitModalContainer.js
@@ -70,7 +70,7 @@ const LocationInfo = ({unit, t, activeLang}) =>
     {get(unit, 'extensions.lighting') && <p>{t('MODAL.LIGHTING') + ': '}<strong>{upperFirst(getAttr(unit.extensions.lighting, activeLang()))}</strong></p>}
     {get(unit, 'extensions.skiing_technique') && <p>{t('MODAL.SKIING_TECHNIQUE') + ': '}<strong>{upperFirst(getAttr(unit.extensions.skiing_technique, activeLang()))}</strong></p>}
     {unit.phone && <p>{t('UNIT.PHONE')}: <a href={`tel:${unit.phone}`}>{unit.phone}</a></p>}
-    {unit.url && <p><a href={getAttr(unit.url, activeLang())} target="_blank">{t('UNIT.FURTHER_INFO')} <SMIcon icon="outbound-link"/></a></p>}
+    {unit.url && <p><a href={getAttr(unit.url, activeLang())} target="_blank" rel="noopener noreferrer">{t('UNIT.FURTHER_INFO')} <SMIcon icon="outbound-link"/></a></p>}
   </ModalBodyBox>;
 
 /**

--- a/src/modules/unit/components/SingleUnitModalContainer.js
+++ b/src/modules/unit/components/SingleUnitModalContainer.js
@@ -7,6 +7,7 @@ import {
   getObservation,
   getOpeningHours,
   getObservationTime,
+  createReittiopasUrl,
 } from '../helpers';
 import {getServiceName} from '../../service/helpers';
 import {translate} from 'react-i18next';
@@ -146,19 +147,11 @@ export class SingleUnitModalContainer extends Component {
     return hasExtensions || unit.phone || unit.url;
   }
 
-  shouldShowRoute(unit) {
-    return unit.connections && (unit.connections.filter((connection) => connection.section === 'traffic')[0]);
-  }
-
-  getRouteUrl(unit, activeLang) {
-    const trafficObject = unit.connections.filter((connection) => connection.section === 'traffic')[0];
-    return getAttr(trafficObject.url, activeLang());
-  }
-
-  render(){
+  render() {
     const {handleClick, isLoading, unit: currentUnit, services, t} = this.props;
     const {getActiveLanguage} = this.context;
     const temperatureObservation = has(currentUnit, 'observations') && getObservation(currentUnit, 'swimming_water_temperature');
+    const routeUrl = currentUnit && createReittiopasUrl(currentUnit, getActiveLanguage());
 
     return (
       <div>
@@ -171,7 +164,7 @@ export class SingleUnitModalContainer extends Component {
               {temperatureObservation && <LocationTemperature t={t} observation={temperatureObservation}/>}
               {this.shouldShowInfo(currentUnit) && <LocationInfo unit={currentUnit} t={t} activeLang={getActiveLanguage}/>}
               {getOpeningHours(currentUnit) && <LocationOpeningHours unit={currentUnit} t={t} activeLang={getActiveLanguage}/>}
-              {this.shouldShowRoute(currentUnit) && <LocationRoute t={t} routeUrl={this.getRouteUrl(currentUnit, getActiveLanguage)} />}
+              {routeUrl && <LocationRoute t={t} routeUrl={routeUrl} />}
             </Modal.Body>
             : null
           }

--- a/src/modules/unit/components/SingleUnitModalContainer.js
+++ b/src/modules/unit/components/SingleUnitModalContainer.js
@@ -70,7 +70,7 @@ const LocationInfo = ({unit, t, activeLang}) =>
     {get(unit, 'extensions.lighting') && <p>{t('MODAL.LIGHTING') + ': '}<strong>{upperFirst(getAttr(unit.extensions.lighting, activeLang()))}</strong></p>}
     {get(unit, 'extensions.skiing_technique') && <p>{t('MODAL.SKIING_TECHNIQUE') + ': '}<strong>{upperFirst(getAttr(unit.extensions.skiing_technique, activeLang()))}</strong></p>}
     {unit.phone && <p>{t('UNIT.PHONE')}: <a href={`tel:${unit.phone}`}>{unit.phone}</a></p>}
-    {unit.url && <p><a href={getAttr(unit.url, activeLang())} target="_blank" rel="noopener noreferrer">{t('UNIT.FURTHER_INFO')} <SMIcon icon="outbound-link"/></a></p>}
+    {unit.www && <p><a href={getAttr(unit.www, activeLang())} target="_blank" rel="noopener noreferrer">{t('UNIT.FURTHER_INFO')} <SMIcon icon="outbound-link"/></a></p>}
   </ModalBodyBox>;
 
 /**

--- a/src/modules/unit/helpers.js
+++ b/src/modules/unit/helpers.js
@@ -7,6 +7,7 @@ import head from 'lodash/head';
 import values from 'lodash/values';
 import upperFirst from 'lodash/upperFirst';
 import memoize from 'lodash/memoize';
+import get from 'lodash/get';
 
 import {createRequest, createUrl} from '../api/helpers.js';
 import {UnitServices, IceSkatingServices, SkiingServices, SwimmingServices} from '../service/constants';
@@ -60,6 +61,21 @@ export const getUnitPosition = (unit: Object): Array<number> => {
   }
 
   return unit.location.coordinates.slice().reverse();
+};
+
+export const createReittiopasUrl = (unit, lang) => {
+  const lat = get(unit, 'location.coordinates[1]');
+  const lon = get(unit, 'location.coordinates[0]');
+  const origin = ' '; // sic
+  const street = getAttr(unit.street_address, lang);
+  const municipality = unit.municipality || '';
+  const coordinates = lat && lon
+    ? encodeURIComponent(`::${lat},${lon}`)
+    : '';
+  const to = encodeURIComponent(`${upperFirst(street)}, ${upperFirst(municipality)}${coordinates}`);
+  const from = encodeURIComponent(origin);
+  const url = `https://reittiopas.hsl.fi/reitti/${from}/${to}`;
+  return url;
 };
 
 export const getUnitSport = (unit: Object) => {


### PR DESCRIPTION
Reittiopas-link used to be generated in API, now it's created here.
Restore additional info link, `unit.url` has changed to `unit.www`.