### PR TITLE
ULK-88 | Sync HTML document language with app language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .nvmrc
 .env
 .idea
+.vscode
 coverage
 flow-typed
 dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Fixed
+
+-   [Accessibility] HTML document language is now synced with application language

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fi">
 <head>
     <meta charset="UTF-8">
     <title>Ulkoliikuntakartta</title>

--- a/src/modules/common/components/translation/TranslationProvider.js
+++ b/src/modules/common/components/translation/TranslationProvider.js
@@ -48,6 +48,7 @@ class TranslationProvider extends React.Component {
       this.forceUpdate();
     } else {
       moment.locale(language);
+      this.changeDocumentLanguage(language);
     }
   }
 
@@ -58,7 +59,12 @@ class TranslationProvider extends React.Component {
   changeLanguage = (nextLanguage) => {
     i18n.changeLanguage(nextLanguage);
     moment.locale(nextLanguage);
-  }
+    this.changeDocumentLanguage(nextLanguage);
+  };
+
+  changeDocumentLanguage = (nextLanguage) => {
+    document.documentElement.lang = nextLanguage;
+  };
 
   render() {
     return <I18nextProvider i18n={i18n}>{this.props.children}</I18nextProvider>;

--- a/src/modules/common/components/translation/__tests__/TranslationProvider.test.js
+++ b/src/modules/common/components/translation/__tests__/TranslationProvider.test.js
@@ -31,13 +31,15 @@ const getWrapper = () => mount(
 );
 
 describe('', () => {
-  it('should have ensure that moment locale and language are in sync', async () => {
+  it('should have ensure that HTML document language, moment locale and language are in sync', async () => {
     const wrapper = await getWrapper();
+    const language = wrapper.find('TranslationProvider').at(0).prop('language');
 
-    expect(wrapper.find('TranslationProvider').at(0).prop('language')).toEqual(moment.locale());
+    expect(moment.locale()).toEqual(language);
+    expect(document.documentElement.lang).toEqual(language);
   });
 
-  it('should change moment language when language changes', async () => {
+  it('should change HTML document language and moment language when language changes', async () => {
     expect(moment.locale()).toEqual('fi');
 
     const wrapper = await getWrapper();
@@ -45,5 +47,6 @@ describe('', () => {
     wrapper.find('button').at(1).simulate('click');
 
     expect(moment.locale()).toEqual('sv');
+    expect(document.documentElement.lang).toEqual('sv');
   });
 });


### PR DESCRIPTION
## Description

The goal of this PR is to make sure that the language of the application matches with the HTML document. This is important for accessibility.

- I changed the default HTML document language into `fi` because that's the default language for the application
- I made sure that the HTML document language is synced with the application language on mount
- I made sure that whenever the application language is changed, so it the HTML document language

The solution should work for this purpose. It would fail if this application were server rendered.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-88](https://helsinkisolutionoffice.atlassian.net/browse/ULK-88)
[ULK-89](https://helsinkisolutionoffice.atlassian.net/browse/ULK-89)

## How Has This Been Tested?

I've modified the `TranslationProvider` test to take HTML document language into account.

## Manual Testing Instructions for Reviewers

1. Start the application
2. Open developer console
3. Expect the HTML `lang` attribute to be `fi` by default
4. Change language
5. Expect for the HTML `lang` attribute to change into that langauge