### PR TITLE
Chore | Run tests in GitHub

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Test
+
+on:
+  push:
+    branches: [ develop, master ]
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Create yarn cache directory path
+      id: yarn-cache
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - name: Cache dependencies
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.yarn-cache.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - name: Install dependencies
+      # Prefer offline to check cache before downloading
+      run: yarn --prefer-offline
+    - name: Run tests
+      run: yarn test --ci --runInBand --collect-coverage
+    - name: Upload coverage report to Codecov
+      uses: codecov/codecov-action@v1

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,14 +16,6 @@ variables:
 build:
   extends: .build
 
-test:
-  extends: .test
-  # Pipeline will use official Node.js image when running the tests.
-  image: node:12
-  script:
-    - yarn
-    - yarn test --ci --runInBand --updateSnapshot
-
 staging:
   # By default the staging environment is created from the master-branch.
   # Here we define that it should be created from the branch called "develop" instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed 
+
+- Run tests in GitHub
+
 ### Fixed
 
 -   [Accessibility] HTML document language is now synced with application language


### PR DESCRIPTION
## Description

GitLab will be decommissioned soon and everything will be moved to GitHub. Therefore, run tests in GitHub as well.
