### PR TITLE
ULK-90 | Add lang attributes to language toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
--   [Accessibility] HTML document language is now synced with application language
+- [Accessibility] HTML document language is now synced with application language
+- [Accessibility] Language toggles now have the correct lang attribute

--- a/src/modules/unit/components/LanguageChanger.js
+++ b/src/modules/unit/components/LanguageChanger.js
@@ -1,0 +1,42 @@
+// @flow
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { SUPPORTED_LANGUAGES } from '../../language/constants';
+
+const LanguageChanger = ({ changeLanguage, activeLanguage, isMobile }) => (
+  <div className={isMobile ? 'language-changer__mobile' : 'language-changer'}>
+    {Object.entries(SUPPORTED_LANGUAGES)
+      .filter(([language]) => SUPPORTED_LANGUAGES[language] !== activeLanguage)
+      .map(([languageKey, languageValue], index) => (
+        <div key={languageKey} style={{ display: 'flex' }}>
+          <a
+            onClick={(e) => {
+              e.preventDefault();
+              changeLanguage(SUPPORTED_LANGUAGES[languageKey]);
+            }}
+            lang={languageValue}
+            // Empty href makes the anchor focusable
+            href
+          >
+            {languageKey}
+          </a>
+          {index < Object.keys(SUPPORTED_LANGUAGES).length - 2 && !isMobile
+            ? <div style={{ marginLeft: 2, marginRight: 2 }}>|</div>
+            : null}
+        </div>
+      ))}
+  </div>
+);
+
+LanguageChanger.propTypes = {
+  changeLanguage: PropTypes.func.isRequired,
+  activeLanguage: PropTypes.string.isRequired,
+  isMobile: PropTypes.bool,
+};
+
+LanguageChanger.defaultProps = {
+  isMobile: false,
+};
+
+export default LanguageChanger;

--- a/src/modules/unit/components/MapView.js
+++ b/src/modules/unit/components/MapView.js
@@ -180,16 +180,26 @@ export default translate(null, { withRef: true })(MapView);
 
 const LanguageChanger = ({ changeLanguage, activeLanguage, isMobile }) => (
   <div className={isMobile ? 'language-changer__mobile' : 'language-changer'}>
-    {Object.keys(SUPPORTED_LANGUAGES).filter((language) => SUPPORTED_LANGUAGES[language] !== activeLanguage).map((languageKey, index) => (
-      <div key={languageKey} style={{ display: 'flex' }}>
-        <a onClick={() => changeLanguage(SUPPORTED_LANGUAGES[languageKey])}>
-          {languageKey}
-        </a>
-        {index < Object.keys(SUPPORTED_LANGUAGES).length - 2 && !isMobile
-          ? <div style={{ marginLeft: 2, marginRight: 2 }}>|</div>
-          : null}
-      </div>
-    ))}
+    {Object.entries(SUPPORTED_LANGUAGES)
+      .filter(([language]) => SUPPORTED_LANGUAGES[language] !== activeLanguage)
+      .map(([languageKey, languageValue], index) => (
+        <div key={languageKey} style={{ display: 'flex' }}>
+          <a
+            onClick={(e) => {
+              e.preventDefault();
+              changeLanguage(SUPPORTED_LANGUAGES[languageKey])
+            }}
+            lang={languageValue}
+            // Empty href makes hte anchor focusable
+            href
+          >
+            {languageKey}
+          </a>
+          {index < Object.keys(SUPPORTED_LANGUAGES).length - 2 && !isMobile
+            ? <div style={{ marginLeft: 2, marginRight: 2 }}>|</div>
+            : null}
+        </div>
+      ))}
   </div>
 );
 

--- a/src/modules/unit/components/MapView.js
+++ b/src/modules/unit/components/MapView.js
@@ -33,6 +33,7 @@ import { getUnitPosition } from '../helpers';
 import UnitsOnMap from './UnitsOnMap';
 import UserLocationMarker from '../../map/components/UserLocationMarker';
 import { isRetina } from '../../common/helpers';
+import LanguageChanger from './LanguageChanger';
 
 class MapView extends Component {
   static propTypes = {
@@ -177,31 +178,6 @@ class MapView extends Component {
 }
 
 export default translate(null, { withRef: true })(MapView);
-
-const LanguageChanger = ({ changeLanguage, activeLanguage, isMobile }) => (
-  <div className={isMobile ? 'language-changer__mobile' : 'language-changer'}>
-    {Object.entries(SUPPORTED_LANGUAGES)
-      .filter(([language]) => SUPPORTED_LANGUAGES[language] !== activeLanguage)
-      .map(([languageKey, languageValue], index) => (
-        <div key={languageKey} style={{ display: 'flex' }}>
-          <a
-            onClick={(e) => {
-              e.preventDefault();
-              changeLanguage(SUPPORTED_LANGUAGES[languageKey])
-            }}
-            lang={languageValue}
-            // Empty href makes hte anchor focusable
-            href
-          >
-            {languageKey}
-          </a>
-          {index < Object.keys(SUPPORTED_LANGUAGES).length - 2 && !isMobile
-            ? <div style={{ marginLeft: 2, marginRight: 2 }}>|</div>
-            : null}
-        </div>
-      ))}
-  </div>
-);
 
 const InfoMenu = ({
   openAboutModal, openFeedbackModal, t, isMobile, activeLanguage, changeLanguage,

--- a/src/modules/unit/components/__tests__/LanguageChanger.test.js
+++ b/src/modules/unit/components/__tests__/LanguageChanger.test.js
@@ -1,0 +1,33 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+
+import { mount } from '../../../common/enzymeHelpers';
+import LanguageChanger from '../LanguageChanger';
+
+const defaultProps = {
+  changeLanguage: jest.fn(),
+  activeLanguage: 'fi',
+};
+const getWrapper = (props) => mount(<LanguageChanger {...defaultProps} {...props} />);
+
+describe('<LanguageChanger />', () => {
+  it('should add a lang attribute to language options', async () => {
+    const wrapper = await getWrapper();
+
+    wrapper.find('a').forEach((element) => {
+      expect(element.prop('lang')).toBeDefined();
+    });
+  });
+
+  it('should change language when an option is clicked', async () => {
+    const preventDefault = jest.fn();
+    const mockEvent = { preventDefault };
+    const wrapper = await getWrapper();
+    const element = wrapper.find('a').at(0);
+
+    element.simulate('click', mockEvent);
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(defaultProps.changeLanguage).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Description

Adds lang attribute to language toggles so that their language content is correctly marked to differ from that of the page.

Also adds a `href` attribute so that the anchor become focusable.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-90](https://helsinkisolutionoffice.atlassian.net/browse/ULK-90)

## How Has This Been Tested?

I've added unit tests to the `LanguageChanger` component that checks that this attribute is applied.

## Manual Testing Instructions for Reviewers

By using a screen reader (for instance CMD+F5 on Mac)

1. Navigate to language controls in the manner you seem fit
2. Expect the content of language links ("Svenska", "English") to be read with the correct voice. In other words, Svenska is read as it would be by a Swedish speaker.
