### PR TITLE
ULK-92 | Make unit modal closable with keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- [Accessibility] HTML document language is now synced with application language
-- [Accessibility] Language toggles now have the correct lang attribute
+-   [Accessibility] HTML document language is now synced with application language
+-   [Accessibility] Language toggles now have the correct lang attribute
+-   [Accessibility] Make unit modal closable with keyboard

--- a/src/modules/unit/components/SingleUnitModalContainer.js
+++ b/src/modules/unit/components/SingleUnitModalContainer.js
@@ -35,13 +35,18 @@ import ObservationStatus, {
 import UnitIcon from './UnitIcon';
 
 const ModalHeader = ({
-  handleClick,
+  handleClick: onClick,
   unit,
   services,
   isLoading,
   activeLang,
   t,
 }) => {
+  const handleClick = (e) => {
+    e.preventDefault();
+    onClick(e);
+  };
+
   const unitAddress = unit ? getAttr(unit.street_address, activeLang()) : null;
   const unitZIP = unit ? unit.address_zip : null;
   const unitMunicipality = unit ? unit.municipality : null;
@@ -63,6 +68,8 @@ const ModalHeader = ({
             <a
               className="modal-close-button close-unit-modal"
               onClick={handleClick}
+              // Href attribute makes the link focusable with a keyboard
+              href
             >
               <SMIcon icon="close" />
             </a>


### PR DESCRIPTION
## Description

Adds a href attribute to the unit close anchor so that it's focusable with the keyboard. Prevents the default action to that it does not refresh the page.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-92](https://helsinkisolutionoffice.atlassian.net/browse/ULK-92)

## How Has This Been Tested?

This has been tested manually. I'll add unit tests in ULK-91.

## Manual Testing Instructions for Reviewers

1. Select an unit (for instance http://localhost:5000/unit/53989)
2. Use tab to navigate page
3. Expect to be able to focus the close button
4. Expect to be able to close the modal with the close button by only using your keyboard
