### PR TITLE
ULK-91 | Add accessible name for unit modal close link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] HTML document language is now synced with application language
 -   [Accessibility] Language toggles now have the correct lang attribute
 -   [Accessibility] Make unit modal closable with keyboard
+-   [Accessibility] Add text label to unit modal close link

--- a/locales/en.json
+++ b/locales/en.json
@@ -62,7 +62,8 @@
     "GET_ROUTE": "Get route to here",
     "NOTICE": "Notice",
     "WATER_TEMPERATURE": "Water temperature",
-    "WATER_TEMPERATURE_SENSOR": "Water temperature sensor"
+    "WATER_TEMPERATURE_SENSOR": "Water temperature sensor",
+    "CLOSE": "Close"
   },
   "VIEW": {
     "POPUP": {

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -62,7 +62,8 @@
     "GET_ROUTE": "Hae reitti tänne",
     "NOTICE": "Tiedote",
     "WATER_TEMPERATURE": "Veden lämpötila",
-    "WATER_TEMPERATURE_SENSOR": "Uimarantasensori"
+    "WATER_TEMPERATURE_SENSOR": "Uimarantasensori",
+    "CLOSE": "Sulje"
   },
   "VIEW": {
     "POPUP": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -62,7 +62,8 @@
     "GET_ROUTE": "Väg hit",
     "NOTICE": "Meddelande",
     "WATER_TEMPERATURE": "Vattnets temperatur",
-    "WATER_TEMPERATURE_SENSOR": "Vattentemperatur sensor"
+    "WATER_TEMPERATURE_SENSOR": "Vattentemperatur sensor",
+    "CLOSE": "Stänga"
   },
   "VIEW": {
     "POPUP": {

--- a/src/modules/unit/components/SingleUnitModalContainer.js
+++ b/src/modules/unit/components/SingleUnitModalContainer.js
@@ -34,7 +34,9 @@ import ObservationStatus, {
 } from './ObservationStatus';
 import UnitIcon from './UnitIcon';
 
-const ModalHeader = ({
+// Export for testing purpose. A bit of an anti-pattern, but required
+// less unrelated work to the feature I was developing
+export const ModalHeader = ({
   handleClick: onClick,
   unit,
   services,
@@ -69,9 +71,9 @@ const ModalHeader = ({
               className="modal-close-button close-unit-modal"
               onClick={handleClick}
               // Href attribute makes the link focusable with a keyboard
-              href
+              href=""
             >
-              <SMIcon icon="close" />
+              <SMIcon icon="close" aria-label={t('MODAL.CLOSE')} />
             </a>
           </div>
         </div>

--- a/src/modules/unit/components/__tests__/SingleUnitModalHeader.test.js
+++ b/src/modules/unit/components/__tests__/SingleUnitModalHeader.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { mount } from '../../../common/enzymeHelpers';
+import { ModalHeader } from '../SingleUnitModalContainer';
+
+const defaultProps = {
+  t: (translationPath) => translationPath,
+};
+const getWrapper = (props) =>
+  mount(<ModalHeader {...defaultProps} {...props} />);
+
+describe('<ModalHeader />', () => {
+  it('should have a close button', async () => {
+    const handleClick = jest.fn();
+    const mockEvent = { preventDefault: jest.fn() };
+    const wrapper = await getWrapper({ handleClick });
+
+    const closeButton = wrapper
+      .find({ 'aria-label': 'MODAL.CLOSE' })
+      .at(0)
+      .parent();
+
+    // It should exists
+    expect(closeButton).toBeTruthy();
+    // It should have an empty href
+    expect(closeButton.prop('href')).toEqual('');
+
+    // Simulating clicks does not work due to some reason I was not able
+    // to pin down. Enzyme's simulate more or less just calls the
+    // onClick function so this should be an equivalent approach.
+    closeButton.prop('onClick')(mockEvent);
+
+    expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(handleClick).toHaveBeenCalledWith(mockEvent);
+  });
+});


### PR DESCRIPTION
## Description

Adds an accessible name for unit modal close link by applying an aria-label to the close icon.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-91](https://helsinkisolutionoffice.atlassian.net/browse/ULK-91)

## How Has This Been Tested?

I've added unit level tests which check the behaviour of the close link.

## Manual Testing Instructions for Reviewers

With a screen reader

1. Navigate to close button (for instance using tab)
2. Expect to hear a name for it (such as "Sulje", "Close" etc.)
