### PR TITLE
ULK-108 | Fix info button that's not reachable with keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] Language toggles now have the correct lang attribute
 -   [Accessibility] Make unit modal closable with keyboard
 -   [Accessibility] Add text label to unit modal close link
+-   [Accessibility] Info button not reachable with keyboard

--- a/src/modules/map/components/Control.js
+++ b/src/modules/map/components/Control.js
@@ -23,7 +23,7 @@ export default class Control extends MapControl {
     // eslint-disable-next-line func-names
     control.onAdd = function () {
       const div = L.DomUtil.create('div', `custom-control ${className}`);
-      const link = L.DomUtil.create('a', 'custom-control-button', div);
+      const link = L.DomUtil.create('button', 'custom-control-button', div);
 
       L.DomEvent.on(link, 'mousedown dblclick', L.DomEvent.stopPropagation)
         .on(link, 'click', L.DomEvent.stop)

--- a/src/modules/map/components/_control.scss
+++ b/src/modules/map/components/_control.scss
@@ -10,9 +10,14 @@
   & &-button {
     display: block;
     width: 26px;
+    height: 26px;
+    padding: 0;
+
     font-size: 19px;
     line-height: 26px;
     text-align: center;
+
+    border: none;
 
     &:hover,
     &:active {


### PR DESCRIPTION
## Description

Also fixes the locator button.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-108](https://helsinkisolutionoffice.atlassian.net/browse/ULK-108)

## How Has This Been Tested?

This has been tested manually. I've checked that the button is accessible by going through the page with <kbd>Shift</kbd> + <kbd>Tab</kbd> in reverse.

## Manual Testing Instructions for Reviewers

1. Go through the page in reverse (to avoid going through the map) with <kbd>Shift</kbd> + <kbd>Tab</kbd>
2. Expect to be able to focus info button
3. Expect to be able to open info menu
