### PR TITLE
ULK-99 | Make search button accessible with keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] Make unit modal closable with keyboard
 -   [Accessibility] Add text label to unit modal close link
 -   [Accessibility] Info button not reachable with keyboard
+-   [Accessibility] Make search button accessible with keyboard and move it after the search field

--- a/locales/en.json
+++ b/locales/en.json
@@ -72,7 +72,10 @@
   },
   "SEARCH": {
     "SEARCH": "Search",
-    "SHOW_ALL_RESULTS": "Show all search results"
+    "SHOW_ALL_RESULTS": "Show all search results",
+    "LOADING": "Loading",
+    "CLEAR": "Clear search",
+    "SUBMIT": "Search"
   },
   "TIME": {
     "DAYS_AGO": "{{days}} days ago",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -72,7 +72,10 @@
   },
   "SEARCH": {
     "SEARCH": "Etsi",
-    "SHOW_ALL_RESULTS": "Näytä kaikki hakutulokset"
+    "SHOW_ALL_RESULTS": "Näytä kaikki hakutulokset",
+    "LOADING": "Ladataan",
+    "CLEAR": "Tyhjennä haku",
+    "SUBMIT": "Etsi"
   },
   "TIME": {
     "DAYS_AGO": "{{days}} päivää sitten",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -72,7 +72,10 @@
   },
   "SEARCH": {
     "SEARCH": "Sök",
-    "SHOW_ALL_RESULTS": "Visa alla sökresultat"
+    "SHOW_ALL_RESULTS": "Visa alla sökresultat",
+    "LOADING": "Läser in",
+    "CLEAR": "Tydlig sökning",
+    "SUBMIT": "Sök"
   },
   "TIME": {
     "DAYS_AGO": "{{days}} dagar sedan",

--- a/src/modules/search/components/SearchBar.js
+++ b/src/modules/search/components/SearchBar.js
@@ -19,17 +19,15 @@ const SearchBar = translate()(
           onSubmit();
         }}
       >
-        <label htmlFor="search">
-          <SMIcon icon="search" />
-        </label>
         {disabled && (
           <span className="search-bar__input-loading" onClick={onClear}>
-            <SMIcon icon="loading" />
+            <SMIcon icon="loading" aria-label={t('SEARCH.LOADING')} />
           </span>
         )}
         <input
           name="search"
           id="search"
+          aria-label={t('SEARCH.SEARCH')}
           type="text"
           onChange={(e) => onInput(e.target.value)}
           placeholder={
@@ -41,10 +39,17 @@ const SearchBar = translate()(
           value={input}
         />
         {(input || searchActive) && (
-          <div className="search-bar__input-clear" onClick={onClear}>
-            <SMIcon icon="close" />
-          </div>
+          <button
+            type="button"
+            className="search-bar__input-clear"
+            onClick={onClear}
+          >
+            <SMIcon icon="close" aria-label={t('SEARCH.CLEAR')} />
+          </button>
         )}
+        <button type="submit" className="search-bar__input-submit">
+          <SMIcon icon="search" aria-label={t('SEARCH.SUBMIT')} />
+        </button>
       </form>
     </div>
   )

--- a/src/modules/search/components/__tests__/SearchBar.test.jsx
+++ b/src/modules/search/components/__tests__/SearchBar.test.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { mount } from '../../../common/enzymeHelpers';
+import SearchBar from '../SearchBar';
+
+const getWrapper = (props) => mount(<SearchBar {...props} />);
+
+describe('<SearchBar />', () => {
+  it('should have an input for making a search', async () => {
+    const value = 'Test value';
+    const onInput = jest.fn();
+    const wrapper = await getWrapper({ onInput });
+    const input = wrapper.find('input[aria-label="Etsi"]').at(0);
+
+    expect(input).toBeTruthy();
+
+    input.simulate('change', { target: { value } });
+
+    expect(onInput).toHaveBeenCalledTimes(1);
+    expect(onInput).toHaveBeenCalledWith(value);
+  });
+
+  it('should have a submit button', async () => {
+    const preventDefault = jest.fn();
+    const onSubmit = jest.fn();
+    const wrapper = await getWrapper({ onSubmit });
+    const submitButton = wrapper.find('button[type="submit"]').at(0);
+
+    expect(submitButton).toBeTruthy();
+
+    // Simulate submit click by clicking submit on invoking form's
+    // onSubmit. Enzyme does not have event propagation.
+    submitButton.simulate('click', { preventDefault });
+    submitButton.parents('form').prop('onSubmit')({ preventDefault });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should have a clear button when the input has content and the searchActive prop is active', async () => {
+    const wrapper = await getWrapper({
+      input: 'Search',
+      searchActive: true,
+    });
+
+    expect(wrapper.find('.search-bar__input-clear').length).toEqual(1);
+  });
+
+  it('should show a loading indicator when disabled is true', async () => {
+    const wrapper = await getWrapper({
+      disabled: true,
+    });
+
+    expect(wrapper.find('[aria-label="Ladataan"]').length).toBeGreaterThan(0);
+  });
+});

--- a/src/modules/search/components/_search-bar.scss
+++ b/src/modules/search/components/_search-bar.scss
@@ -4,6 +4,7 @@
     background: $ui-content;
     display: flex;
     align-items: center;
+    position: relative;
 
     input[name='search'] {
       flex: 2 1 auto;
@@ -27,9 +28,10 @@
 
     &-clear {
       position: absolute;
-      right: 50px + 4 * $gap;
-      top: 3 * $gap;
-      cursor: pointer;
+      right: 40px;
+
+      border: none;
+      background: none;
     }
 
     @keyframes spin {
@@ -43,24 +45,23 @@
 
     &-loading {
       position: absolute;
-      top: 24px;
-      left: 50px;
+      left: 16px;
       animation: spin 1s linear infinite;
     }
 
-    label {
+    &-submit {
       flex: 0 1 auto;
-      color: $ui-text;
-      padding-right: 6px;
       display: inline-block;
-      font-size: 18px;
-      line-height: 30px;
+      padding-right: 6px;
       margin: 0;
       width: 24px;
 
-      &:hover {
-        cursor: pointer;
-      }
+      font-size: 18px;
+      line-height: 30px;
+      color: $ui-text;
+
+      border: none;
+      background: none;
     }
   }
 }


### PR DESCRIPTION
## Description

Improves the accessibility of the search by making the search button
accessible with a keyboard and by moving it after the search input.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-99](https://helsinkisolutionoffice.atlassian.net/browse/ULK-99)

## How Has This Been Tested?

I've added unit/integration levels test which check the search form.

## Manual Testing Instructions for Reviewers

While using a screen reader

1. Expect to see search button after the search input
2. Expect for search button to come after search input in tab order
3. Expect search button to have an accessible name
4. Expect clear search button to have an accessible name
5. Expect search input to have an accessible name
