### PR TITLE
ULK-93 | Add jump link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] Make search button accessible with keyboard and move it after the search field
 -   [Accessibility] Add accessible names to map and list buttons
 -   [Accessibility] Warn when links open a new window
+-   [Accessibility] Add jump link

--- a/locales/en.json
+++ b/locales/en.json
@@ -9,7 +9,7 @@
   "MAP": {
     "ATTRIBUTION": "OpenStreetMap contributors",
     "ABOUT": "<h2>Outdoor Exercise Map</h2> <h3>Information on the service</h3> <p>The Outdoor Exercise Map is an open communications channel for checking the condition of outdoor sports facilities in Helsinki, Espoo and Vantaa. The Outdoor Exercise Map helps the inhabitants of the municipality find up-to-date information on the City’s outdoor sports services. Currently, the services encompasses the skiing tracks and ice-skating fields maintained by the cities and in the spring it will also contain beaches.</p> <p>The service has been created in cooperation between the <a target='_blank' href='http://www.hel.fi/www/kanslia/en/divisions/information/'>ICT unit</a> of the Information and Communication Technology division at the Helsinki City Executive Office and  <a target='_blank' href='http://www.hel.fi/www/liv/en'>the City of Helsinki Sports Department</a>.</p> <h3>Feedback</h3> <p>We are grateful for all your feedback, it allows us to develop the Outdoor Exercise Map and make it even better.</p> <h3>© Information and copyright</h3> <p>The Outdoor Exercise Map has been constructed using as open data as possible and open-source code.</p> <p>The source code of the map is on <a target='_blank' href='https://github.com/nordsoftware/outdoors-sports-map'>GitHub</a> and we encourage development of it.</p> <p>The sports facility information is open data and usable through the REST interface.</p> <p>The map data is from <a target='_blank' href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> and the copyright of the maps belongs to <a target='_blank' href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>.</p> <p>The address information is from Helsinki Region Transport’s <a target='_blank' href='http://developer.reittiopas.fi/'>open interface</a>.</p>",
-    "INFO_MENU" : {
+    "INFO_MENU": {
       "GIVE_FEEDBACK": "Give feedback",
       "ABOUT_SERVICE": "Information on the service",
       "CHOOSE_LANGUAGE": "Choose language"
@@ -27,7 +27,7 @@
     "STATUS": "Condition",
     "UNKNOWN": "Unknown",
     "UPDATED": "Updated",
-    "MAINTENANCE_DONE" : "Maintained",
+    "MAINTENANCE_DONE": "Maintained",
     "FILTER": {
       "STATUS_ALL": "In all conditions",
       "ICE_SKATING": "Ice-skating",
@@ -91,5 +91,8 @@
   },
   "OUTBOUND_LINK": {
     "DESCRIPTION": "Opens a new window"
+  },
+  "JUMP_LINK": {
+    "LABEL": "Jump straight to content"
   }
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -9,7 +9,7 @@
   "MAP": {
     "ATTRIBUTION": "OpenStreetMap tekijät",
     "ABOUT": "<h2>Ulkoliikuntakartta</h2> <h3>Tietoa palvelusta</h3> <p>Ulkoliikuntakartta on avoin tiedotuskanava Helsingin, Espoon ja Vantaan kaupunkien ulkoliikuntapaikkojen kunnosta. Ulkoliikuntakartta opastaa kuntalaisia löytämään ajantasaisen tiedon kaupungin ylläpitämistä ulkoliikuntapalveluista. Tällä hetkellä palvelu kattaa kaupunkien ylläpitämät hiihtoladut ja luistelupaikat, ja keväällä palveluun tulee uimarannat.</p> <p>Palvelu on toteutettu Helsingin kaupungin kaupunginkanslian <a target='_blank' href='http://www.hel.fi/www/kanslia/fi/osastot-ja-yksikot/tietotekniikka/'>tietotekniikka- ja viestintäosaston tietotekniikkayksikön</a> ja <a target='_blank' href='https://hel.fi/liikunta/'>Helsingin kaupungin liikuntaviraston</a> yhteistyönä.</p> <h3>Palaute</h3> <p>Kiitämme kaikesta palautteesta, jotta voimme kehittää Ulkoliikuntakarttaa yhä paremmaksi.</p> <h3>© Tiedot ja tekijänoikeudet</h3> <p>Ulkoliikuntakartta on rakennettu mahdollisimman avointa dataa ja avointa lähdekoodia käyttäen.</p> <p>Kartan lähdekoodi löytyy <a target='_blank' href='https://github.com/nordsoftware/outdoors-sports-map'>GitHubista</a> ja sen kehittämiseen rohkaistaan.</p> <p>Liikuntapaikkojen tiedot ovat avointa dataa ja käytettävissä REST-rajapinnan kautta.</p> <p>Karttatiedot haetaan avoimesta <a target='_blank' href='https://www.openstreetmap.org/copyright'>OpenStreetMapista</a> ja niiden tekijänoikeus kuuluu <a target='_blank' href='https://www.openstreetmap.org/copyright'>OpenStreetMapin tekijöille.</a></p> <p>Osoitetietojen hakuun käytetään Helsingin seudun liikenteen <a target='_blank' href='http://developer.reittiopas.fi/'>avointa rajapintaa</a></p>",
-    "INFO_MENU" : {
+    "INFO_MENU": {
       "GIVE_FEEDBACK": "Anna palautetta",
       "ABOUT_SERVICE": "Tietoa palvelusta",
       "CHOOSE_LANGUAGE": "Valitse kieli"
@@ -27,7 +27,7 @@
     "STATUS": "Kunto",
     "UNKNOWN": "Tuntematon",
     "UPDATED": "Päivitetty",
-    "MAINTENANCE_DONE" : "Kunnostettu",
+    "MAINTENANCE_DONE": "Kunnostettu",
     "FILTER": {
       "STATUS_ALL": "Kaikenkuntoiset",
       "ICE_SKATING": "Luistelu",
@@ -91,5 +91,8 @@
   },
   "OUTBOUND_LINK": {
     "DESCRIPTION": "Avaa uuden ikkunan"
+  },
+  "JUMP_LINK": {
+    "LABEL": "Siirry suoraan sisältöön"
   }
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -9,7 +9,7 @@
   "MAP": {
     "ATTRIBUTION": "OpenStreetMaps skapare",
     "ABOUT": "<h2>Utemotionskarta</h2> <h3>Information om tjänsten</h3> <p>Utemotionskartan är en öppen kommunikationskanal om skicket på anläggningarna för utomhusidrott i Helsingfors, Esbo och Vanda. Utemotionskartan hjälper kommuninvånarna att hitta uppdaterad information om de tjänster för utomhusidrott som staden upprätthåller. I nuläget omfattar tjänsten stadens skidspår och skridskoplaner och på våren kommer den också att omfatta badstränder.</p> <p>Tjänsten har förverkligats i samverkan mellan <a target='_blank' href='http://www.hel.fi/www/kanslia/fi/osastot-ja-yksikot/tietotekniikka/'>informationstekniksenheten</a> vid IT- och kommunikationsavdelningen på Helsingfors stads stadskansli och Helsingfors stads <a target='_blank' href='https://hel.fi/liikunta/'>idrottsverk</a>. <h3>Respons</h3> <p>Vi är tacksamma för all respons, så att vi kan utveckla Utemotionskartan och göra den allt bättre.</p> <h3>© Information och upphovsrätt</h3> <p>Utemotionskartan har byggs med hjälp av så öppna data som möjligt och öppen källkod.</p> <p>Kartans källkod finns på <a target='_blank' href='https://github.com/nordsoftware/outdoors-sports-map'>GitHub</a> och vi uppmuntrar till utveckling av den.</p> <p>Idrottsplatsernas uppgifter är öppna data och användbara via REST-gränssnittet.</p> <p>Kartuppgifterna hämtas från öppna <a target='_blank' href='https://www.openstreetmap.org/'>OpenStreetMap</a> och kartornas upphovsrätt hör till <a target='_blank' href='https://www.openstreetmap.org/copyright'>OpenStreetMaps skapare.</a></p> <p>Adressuppgifterna hämtas med hjälp av Helsingforsregionens trafiks <a target='_blank' href='http://developer.reittiopas.fi/'>öppna gränssnitt</a>.",
-    "INFO_MENU" : {
+    "INFO_MENU": {
       "GIVE_FEEDBACK": "Ge respons",
       "ABOUT_SERVICE": "Information om tjänsten",
       "CHOOSE_LANGUAGE": "Välj språk"
@@ -27,7 +27,7 @@
     "STATUS": "Skick",
     "UNKNOWN": "Okänt",
     "UPDATED": "Uppdaterad",
-    "MAINTENANCE_DONE" : "Iståndsatt",
+    "MAINTENANCE_DONE": "Iståndsatt",
     "FILTER": {
       "STATUS_ALL": "I alla skick",
       "ICE_SKATING": "Skridskoåkning",
@@ -91,5 +91,8 @@
   },
   "OUTBOUND_LINK": {
     "DESCRIPTION": "Öppnar ett nytt fönster"
+  },
+  "JUMP_LINK": {
+    "LABEL": "Gå direkt till innehållet"
   }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -6,6 +6,7 @@
 @import 'modules/common/variables';
 @import 'modules/common/common';
 @import 'modules/common/components/outbound-link';
+@import 'modules/common/components/page';
 @import 'modules/common/components/jump-link';
 @import 'modules/home/components/home';
 @import 'modules/home/components/logo';

--- a/src/index.scss
+++ b/src/index.scss
@@ -6,6 +6,7 @@
 @import 'modules/common/variables';
 @import 'modules/common/common';
 @import 'modules/common/components/outbound-link';
+@import 'modules/common/components/jump-link';
 @import 'modules/home/components/home';
 @import 'modules/home/components/logo';
 @import 'modules/home/components/disclaimer';

--- a/src/modules/common/_common.scss
+++ b/src/modules/common/_common.scss
@@ -15,3 +15,7 @@ body {
 #root {
   height: 100%;
 }
+
+#app-wrapper {
+  height: 100%;
+}

--- a/src/modules/common/components/App.js
+++ b/src/modules/common/components/App.js
@@ -2,8 +2,9 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { Router, Route, IndexRoute } from 'react-router';
 import HomeContainer from '../../home/components/HomeContainer';
-import TranslationProvider from './translation/TranslationProvider';
 import { routerPaths } from '../constants';
+import TranslationProvider from './translation/TranslationProvider';
+import JumpLink from './JumpLink';
 
 const routes = (
   <Route path="/">
@@ -16,7 +17,10 @@ const routes = (
 const App = ({ store, history }) => (
   <Provider store={store}>
     <TranslationProvider>
-      <Router history={history} routes={routes} key={Math.random()} />
+      <div>
+        <JumpLink />
+        <Router history={history} routes={routes} key={Math.random()} />
+      </div>
     </TranslationProvider>
   </Provider>
 );

--- a/src/modules/common/components/App.js
+++ b/src/modules/common/components/App.js
@@ -17,7 +17,7 @@ const routes = (
 const App = ({ store, history }) => (
   <Provider store={store}>
     <TranslationProvider>
-      <div>
+      <div id="app-wrapper">
         <JumpLink />
         <Router history={history} routes={routes} key={Math.random()} />
       </div>

--- a/src/modules/common/components/JumpLink.js
+++ b/src/modules/common/components/JumpLink.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate } from 'react-i18next';
+
+import { MAIN_CONTENT_ID } from './Page';
+
+const JumpLink = ({ t }) => (
+  <a href={`#${MAIN_CONTENT_ID}`} className="jump-link">
+    {t('JUMP_LINK.LABEL')}
+  </a>
+);
+
+JumpLink.propTypes = {
+  t: PropTypes.func.isRequired,
+};
+
+export default translate()(JumpLink);

--- a/src/modules/common/components/Page.js
+++ b/src/modules/common/components/Page.js
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 
 export const MAIN_CONTENT_ID = 'main-content';
 
-const Page = ({ children }) => <main id={MAIN_CONTENT_ID}>{children}</main>;
+const Page = ({ children }) => (
+  <main id={MAIN_CONTENT_ID} className="main-content">
+    {children}
+  </main>
+);
 
 Page.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/modules/common/components/Page.js
+++ b/src/modules/common/components/Page.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const MAIN_CONTENT_ID = 'main-content';
+
+const Page = ({ children }) => <main id={MAIN_CONTENT_ID}>{children}</main>;
+
+Page.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Page;

--- a/src/modules/common/components/__tests__/JumpLink.test.js
+++ b/src/modules/common/components/__tests__/JumpLink.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { mount } from '../../enzymeHelpers';
+import JumpLink from '../JumpLink';
+import { MAIN_CONTENT_ID } from '../Page';
+
+const getWrapper = (props) => mount(<JumpLink {...props} />);
+
+describe('<JumpLink />', () => {
+  it('should render an anchor with id of MAIN_CONTENT_ID', async () => {
+    const wrapper = await getWrapper();
+
+    expect(wrapper.find(`a[href="#${MAIN_CONTENT_ID}"]`).length).toEqual(1);
+  });
+});

--- a/src/modules/common/components/__tests__/Page.test.js
+++ b/src/modules/common/components/__tests__/Page.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { mount } from '../../enzymeHelpers';
+import Page, { MAIN_CONTENT_ID } from '../Page';
+
+const getWrapper = (props) => mount(<Page {...props} />);
+
+describe('<Page />', () => {
+  it('should render children within <main />', async () => {
+    const children = <div id="test" />;
+    const wrapper = await getWrapper({ children });
+
+    expect(wrapper.find(`main#${MAIN_CONTENT_ID}`).prop('children')).toEqual(
+      children
+    );
+  });
+});

--- a/src/modules/common/components/_jump-link.scss
+++ b/src/modules/common/components/_jump-link.scss
@@ -1,0 +1,24 @@
+.jump-link.jump-link {
+  position: fixed;
+  top: 2px;
+  left: 2px;
+  z-index: 10000;
+  padding: 2rem 4rem;
+
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+
+  background: #000;
+
+  &:not(:focus) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+  }
+}

--- a/src/modules/common/components/_page.scss
+++ b/src/modules/common/components/_page.scss
@@ -1,0 +1,3 @@
+.main-content {
+  height: 100%;
+}

--- a/src/modules/home/components/HomeContainer.js
+++ b/src/modules/home/components/HomeContainer.js
@@ -30,6 +30,7 @@ import UnitBrowser from '../../unit/components/UnitBrowser';
 import SingleUnitModalContainer from '../../unit/components/SingleUnitModalContainer';
 import { locations } from '../constants';
 import { arrayifyQueryValue } from '../../common/helpers';
+import Page from '../../common/components/Page';
 import { SUPPORTED_LANGUAGES } from '../../language/constants';
 
 type Props = {
@@ -174,44 +175,46 @@ class HomeContainer extends Component<DefaultProps, Props, void> {
       : getDefaultFilters();
 
     return (
-      <div className="home">
-        <UnitBrowser
-          isLoading={isLoading}
-          isSearching={isSearching}
-          units={unitData}
-          services={serviceData}
-          activeFilter={activeFilter}
-          openUnit={this.openUnit}
-          position={mapCenter}
-          address={address}
-          params={params}
-          setLocation={this.setLocation}
-          setView={this.setView}
-          leafletMap={this.leafletMap}
-          singleUnitSelected={!!params.unitId}
-        />
-        <MapView
-          ref="map"
-          selectedUnit={selectedUnit}
-          activeLanguage={activeLanguage}
-          params={params}
-          setLocation={this.props.setLocation}
-          position={this.initialPosition}
-          units={unitData}
-          services={serviceData}
-          changeLanguage={this.handleChangeLanguage}
-          openUnit={this.openUnit}
-          mapCenter={mapCenter}
-        />
-        <SingleUnitModalContainer
-          isLoading={isLoading}
-          isOpen={!!params.unitId}
-          unit={selectedUnit}
-          services={serviceData}
-          params={params}
-          handleClick={this.closeUnit}
-        />
-      </div>
+      <Page>
+        <div className="home">
+          <UnitBrowser
+            isLoading={isLoading}
+            isSearching={isSearching}
+            units={unitData}
+            services={serviceData}
+            activeFilter={activeFilter}
+            openUnit={this.openUnit}
+            position={mapCenter}
+            address={address}
+            params={params}
+            setLocation={this.setLocation}
+            setView={this.setView}
+            leafletMap={this.leafletMap}
+            singleUnitSelected={!!params.unitId}
+          />
+          <MapView
+            ref="map"
+            selectedUnit={selectedUnit}
+            activeLanguage={activeLanguage}
+            params={params}
+            setLocation={this.props.setLocation}
+            position={this.initialPosition}
+            units={unitData}
+            services={serviceData}
+            changeLanguage={this.handleChangeLanguage}
+            openUnit={this.openUnit}
+            mapCenter={mapCenter}
+          />
+          <SingleUnitModalContainer
+            isLoading={isLoading}
+            isOpen={!!params.unitId}
+            unit={selectedUnit}
+            services={serviceData}
+            params={params}
+            handleClick={this.closeUnit}
+          />
+        </div>
+      </Page>
     );
   }
 }


### PR DESCRIPTION
## Description

Add a jump to content link to the beginning of the page.

It should be hidden by default, but become visible when focused. It should be the first focusable element on the page. The should move the user's focus to the main content, skipping any repeated content.

Note that currently there's no repeated content on this application so nothing is skipped.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-93](https://helsinkisolutionoffice.atlassian.net/browse/ULK-93)

## How Has This Been Tested?

I've added unit level tests which check the new JumpLink and Page components.

## Manual Testing Instructions for Reviewers

While using a screen reader

1. Expect to see no skip to content link by default
2. When tabbing into the page expect jump to content link to become visible
3. Expect link to move focus into main content
