### PR TITLE
ULK-95 | Warn when opening link in a new window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] Info button not reachable with keyboard
 -   [Accessibility] Make search button accessible with keyboard and move it after the search field
 -   [Accessibility] Add accessible names to map and list buttons
+-   [Accessibility] Warn when links open a new window

--- a/locales/en.json
+++ b/locales/en.json
@@ -88,5 +88,8 @@
     "WEEK_AGO": "a week ago",
     "WEEKS_AGO": "{{weeks}} weeks ago",
     "YESTERDAY": "yesterday"
+  },
+  "OUTBOUND_LINK": {
+    "DESCRIPTION": "Opens a new window"
   }
 }

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -88,5 +88,8 @@
     "WEEK_AGO": "viikko sitten",
     "WEEKS_AGO": "{{weeks}} viikkoa sitten",
     "YESTERDAY": "eilen"
+  },
+  "OUTBOUND_LINK": {
+    "DESCRIPTION": "Avaa uuden ikkunan"
   }
 }

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -88,5 +88,8 @@
     "WEEK_AGO": "en vecka sedan",
     "WEEKS_AGO": "{{weeks}} veckor sedan",
     "YESTERDAY": "i går"
+  },
+  "OUTBOUND_LINK": {
+    "DESCRIPTION": "Öppnar ett nytt fönster"
   }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,6 +5,7 @@
 @import '../assets/fonts/outdoor-sports-icons.css';
 @import 'modules/common/variables';
 @import 'modules/common/common';
+@import 'modules/common/components/outbound-link';
 @import 'modules/home/components/home';
 @import 'modules/home/components/logo';
 @import 'modules/home/components/disclaimer';

--- a/src/modules/common/components/OutboundLink.js
+++ b/src/modules/common/components/OutboundLink.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate } from 'react-i18next';
+
+const OutboundLink = translate()(({ t, href, children, ...rest }) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="outbound-link"
+    {...rest}
+  >
+    {children}{' '}
+    <span className="outbound-link__outbound_warning">
+      {t('OUTBOUND_LINK.DESCRIPTION')}
+    </span>
+  </a>
+));
+
+OutboundLink.propTypes = {
+  href: PropTypes.string.isRequired,
+  children: PropTypes.string.isRequired,
+};
+
+export default OutboundLink;

--- a/src/modules/common/components/__tests__/OutboundLink.test.js
+++ b/src/modules/common/components/__tests__/OutboundLink.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { mount } from '../../enzymeHelpers';
+import OutboundLink from '../OutboundLink';
+
+const defaultProps = {
+  href: 'http://localhost',
+  children: 'Label',
+};
+const getWrapper = (props) =>
+  mount(<OutboundLink {...defaultProps} {...props} />);
+
+describe('<OutboundLink />', () => {
+  it('should render a link with notice that it will be opened into a new window', async () => {
+    const wrapper = await getWrapper();
+    const link = wrapper.find('a');
+
+    expect(link.length).toEqual(1);
+    expect(link.find('[aria-label="Avaa uuden ikkunan"]'));
+  });
+});

--- a/src/modules/common/components/_outbound-link.scss
+++ b/src/modules/common/components/_outbound-link.scss
@@ -1,0 +1,27 @@
+.outbound-link {
+  position: relative;
+  overflow: visible;
+
+  &__outbound_warning {
+    position: absolute;
+    left: -12000px;
+    width: 0;
+    overflow: hidden;
+  }
+
+  &:focus &__outbound_warning,
+  &:active &__outbound_warning,
+  &:hover &__outbound_warning {
+    display: block;
+    left: 0;
+    top: 2.5rem;
+    padding: 0.5rem 1.5rem;
+    width: max-content;
+
+    color: #000;
+
+    border: 2px solid #000;
+    background: #fff;
+    font-weight: 600;
+  }
+}

--- a/src/modules/home/components/Disclaimer.js
+++ b/src/modules/home/components/Disclaimer.js
@@ -2,14 +2,16 @@ import React from 'react';
 import { Link } from 'react-router';
 import { translate } from 'react-i18next';
 
+import OutboundLink from '../../common/components/OutboundLink';
+
 export default translate()(({ attributionLink, t }) => (
   <div className="disclaimer">
     <div className="disclaimer__content">
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <Link to="#">{t('APP.ABOUT')}</Link>
-      <a target="_blank" href={attributionLink} rel="noopener noreferrer">
+      <OutboundLink href={attributionLink}>
         {t('MAP.ATTRIBUTION')}{' '}
-      </a>
+      </OutboundLink>
     </div>
   </div>
 ));

--- a/src/modules/unit/components/MapView.js
+++ b/src/modules/unit/components/MapView.js
@@ -38,6 +38,7 @@ import { getUnitPosition } from '../helpers';
 import UnitsOnMap from './UnitsOnMap';
 import UserLocationMarker from '../../map/components/UserLocationMarker';
 import { isRetina } from '../../common/helpers';
+import OutboundLink from '../../common/components/OutboundLink';
 import LanguageChanger from './LanguageChanger';
 
 class MapView extends Component {
@@ -240,15 +241,10 @@ const InfoMenu = ({
       {t('MAP.INFO_MENU.ABOUT_SERVICE')}
     </InfoMenuItem>
     <InfoMenuItem handleClick={() => null}>
-      <a
-        target="_blank"
-        href="http://osm.org/copyright"
-        rel="noopener noreferrer"
-        style={{ padding: 1 }}
-      >
+      <OutboundLink href="http://osm.org/copyright" style={{ padding: 1 }}>
         &copy;
         {t('MAP.ATTRIBUTION')}{' '}
-      </a>
+      </OutboundLink>
     </InfoMenuItem>
     {isMobile && Object.keys(SUPPORTED_LANGUAGES).length > 1 && (
       <InfoMenuItem handleClick={() => null}>

--- a/src/modules/unit/components/SingleUnitModalContainer.js
+++ b/src/modules/unit/components/SingleUnitModalContainer.js
@@ -28,6 +28,7 @@ import {
   createReittiopasUrl,
 } from '../helpers';
 import getServiceName from '../../service/helpers';
+import OutboundLink from '../../common/components/OutboundLink';
 import ObservationStatus, {
   StatusUpdated,
   StatusUpdatedAgo,
@@ -140,13 +141,9 @@ const LocationInfo = ({ unit, t, activeLang }) => (
     )}
     {unit.www && (
       <p>
-        <a
-          href={getAttr(unit.www, activeLang())}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <OutboundLink href={getAttr(unit.www, activeLang())}>
           {t('UNIT.FURTHER_INFO')} <SMIcon icon="outbound-link" />
-        </a>
+        </OutboundLink>
       </p>
     )}
   </ModalBodyBox>
@@ -178,9 +175,7 @@ const NoticeInfo = ({ unit, t, activeLang }) => {
 
 const LocationRoute = ({ routeUrl, t }) => (
   <ModalBodyBox title={t('MODAL.ROUTE_HERE')}>
-    <a target="_blank" href={routeUrl} rel="noopener noreferrer">
-      {t('MODAL.GET_ROUTE')}
-    </a>
+    <OutboundLink href={routeUrl}>{t('MODAL.GET_ROUTE')}</OutboundLink>
   </ModalBodyBox>
 );
 


### PR DESCRIPTION
## Description

Refactors outbound links into its own component. The component implements a warning message that's visible while hovering, focusing or holding an element active. 

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-95](https://helsinkisolutionoffice.atlassian.net/browse/ULK-95)

## How Has This Been Tested?

I've unit tested the new component and used a screen reader to ensure that the warning is read as expected.

## Manual Testing Instructions for Reviewers

With a screen reader

1. Access Allas Seapool: `/unit/50401`
2. Browse through the links
3. Expect to hear "Open a new window" when accessing links that target a new window
4. Expect to see a black bordered white box with black text
