### PR TITLE
ULK-109 | Show all opening hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 -   Run tests in GitHub
 -   Use prettier to format project
+-   Show all opening hours
 
 ### Fixed
 

--- a/src/modules/unit/components/SingleUnitModalContainer.js
+++ b/src/modules/unit/components/SingleUnitModalContainer.js
@@ -195,11 +195,23 @@ const LocationRoute = ({ routeUrl, t }) => (
 //     Wow such profile.
 //   </ModalBodyBox>;
 
-const LocationOpeningHours = ({ unit, t, activeLang }) => (
-  <ModalBodyBox title={t('MODAL.OPENING_HOURS')}>
-    {getOpeningHours(unit, activeLang())}
-  </ModalBodyBox>
-);
+const LocationOpeningHours = ({ unit, t, activeLang }) => {
+  const openingHours = getOpeningHours(unit, activeLang());
+
+  if (openingHours.length === 0) {
+    return null;
+  }
+
+  return (
+    <ModalBodyBox title={t('MODAL.OPENING_HOURS')}>
+      {openingHours.map((openingHour) => (
+        <div key={openingHour.id} className="modal-body-multi-line">
+          {openingHour}
+        </div>
+      ))}
+    </ModalBodyBox>
+  );
+};
 
 const LocationTemperature = ({ t, observation }) => {
   const temperature = get(observation, 'name.fi');

--- a/src/modules/unit/components/_single-unit-modal.scss
+++ b/src/modules/unit/components/_single-unit-modal.scss
@@ -76,6 +76,15 @@
         margin-bottom: 3px;
       }
     }
+
+    &-multi-line {
+      white-space: pre-wrap;
+      margin-top: 2rem;
+
+      & > * {
+        display: inline-block;
+      }
+    }
   }
 
   &-close-button {

--- a/src/modules/unit/helpers.js
+++ b/src/modules/unit/helpers.js
@@ -125,18 +125,20 @@ export const getUnitQuality = (unit: Object): string => {
   return observation ? observation.quality : UnitQuality.UNKNOWN;
 };
 
-export const getOpeningHours = (unit: Object, activeLang: string): string => {
-  // eslint-disable-next-line no-restricted-syntax
-  for (const service of unit.services) {
-    if (
-      service === UnitServices.MECHANICALLY_FROZEN_ICE &&
-      unit.connections &&
-      unit.connections[1]
-    ) {
-      return getAttr(unit.connections[1].name, activeLang) || '';
-    }
+export const getOpeningHours = (unit: Object, activeLang: string): string[] => {
+  const isMechanicallyFrozenIce = unit.services.includes(
+    UnitServices.MECHANICALLY_FROZEN_ICE
+  );
+
+  if (!isMechanicallyFrozenIce) {
+    return [];
   }
-  return '';
+
+  const connections = unit.connections || [];
+
+  return connections
+    .filter((connection) => connection.section_type === 'OPENING_HOURS')
+    .map((connection) => getAttr(connection.name, activeLang));
 };
 
 export const getObservationTime = (observation: Object) =>


### PR DESCRIPTION
## Description

Current logic for rendering opening hours picks one opening hour to render. This PR changes the code so that all opening hours are rendered. Opening hours should be separated by a slight margin.

## Context

[ULK-109](https://helsinkisolutionoffice.atlassian.net/browse/ULK-109)

## How Has This Been Tested?

This has been tested manually.

## Manual Testing Instructions for Reviewers

1. Access unit `/unit/40493` (for instance https://outdoors-sports-map-feature-ul-53.newtest.kuva.hel.ninja/unit/40493)
2. Expect to see a long body of text.
    3. Some things may be formatted oddly. That's OK.
