### PR TITLE
ULK-98 | Fix insufficient labels on sub menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+-   [Accessibility] Fix insufficient labels on sub menus
+
 ## [1.1.2] - 2021-01-05
 
 ### Changed

--- a/locales/en.json
+++ b/locales/en.json
@@ -35,8 +35,8 @@
       "STATUS_OK": "In usable condition",
       "SWIMMING": "Swimming"
     },
-    "FILTER_SPORT": "Sport",
-    "FILTER_STATUS": "Condition",
+    "FILTER_SPORT": "Choose Sport",
+    "FILTER_STATUS": "Choose Condition",
     "SORT": {
       "DEFAULT": "Default",
       "ALPHABETICAL": "Alphabetic",

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -35,8 +35,8 @@
       "STATUS_OK": "Käyttökuntoiset",
       "SWIMMING": "Uinti"
     },
-    "FILTER_SPORT": "Laji",
-    "FILTER_STATUS": "Kunto",
+    "FILTER_SPORT": "Valitse laji",
+    "FILTER_STATUS": "Valitse kunto",
     "SORT": {
       "DEFAULT": "Oletus",
       "ALPHABETICAL": "Aakkosellinen",

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -35,8 +35,8 @@
       "STATUS_OK": "I användbart skick",
       "SWIMMING": "Simning"
     },
-    "FILTER_SPORT": "Sportgren",
-    "FILTER_STATUS": "Skick",
+    "FILTER_SPORT": "Välj sportgren",
+    "FILTER_STATUS": "Välj skick",
     "SORT": {
       "DEFAULT": "Förinställt",
       "ALPHABETICAL": "Alfabetisk",

--- a/src/modules/unit/__tests__/UnitFilterLabel.test.js
+++ b/src/modules/unit/__tests__/UnitFilterLabel.test.js
@@ -3,16 +3,7 @@ import { shallow } from 'enzyme';
 
 import UnitFilterLabel from '../components/UnitFilterLabel';
 
-jest.mock('react-i18next', () => ({
-  // this mock makes sure any components using the translate HoC receive the t function as a prop
-  translate: () => (Component) => {
-    // eslint-disable-next-line no-param-reassign
-    Component.defaultProps = { ...Component.defaultProps, t: (k) => k };
-    return Component;
-  },
-}));
-
 it('renders snapshot correctly', () => {
-  const unitFilterLabel = shallow(<UnitFilterLabel filterName="sport" />);
+  const unitFilterLabel = shallow(<UnitFilterLabel message="sport" />);
   expect(unitFilterLabel.html()).toMatchSnapshot();
 });

--- a/src/modules/unit/__tests__/__snapshots__/UnitFilterLabel.test.js.snap
+++ b/src/modules/unit/__tests__/__snapshots__/UnitFilterLabel.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders snapshot correctly 1`] = `"<div class=\\"unit-filter-label\\"><span>UNIT.FILTER_SPORT:</span></div>"`;
+exports[`renders snapshot correctly 1`] = `"<div class=\\"unit-filter-label\\"><span>sport:</span></div>"`;

--- a/src/modules/unit/components/DropdownIndicator.js
+++ b/src/modules/unit/components/DropdownIndicator.js
@@ -3,7 +3,7 @@ import React from 'react';
 import SMIcon from '../../home/components/SMIcon';
 
 const DropdownIndicator = () => (
-  <span className="dropdown-indicator">
+  <span className="dropdown-indicator" aria-hidden="true">
     <SMIcon icon="expand" />
   </span>
 );

--- a/src/modules/unit/components/UnitFilterButton.js
+++ b/src/modules/unit/components/UnitFilterButton.js
@@ -1,29 +1,29 @@
 // @flow
 import React from 'react';
 import { Button } from 'react-bootstrap';
-import invert from 'lodash/invert';
 import UnitFilterIcon from './UnitFilterIcon';
 import DropdownIndicator from './DropdownIndicator';
-import { UnitFilters } from '../constants';
 
 const UnitFilterButton = ({
-  t,
   filterName,
   className,
   // eslint-disable-next-line react/prop-types
   showDropdownIndicator = false,
+  message,
   ...rest
 }: {
-  t: () => string,
   filterName: string,
   className: string,
+  message: string,
 }) => (
   // eslint-disable-next-line react/jsx-props-no-spreading
   <Button className={`unit-filter-button ${className}`} {...rest}>
-    <UnitFilterIcon className="unit-filter-button__icon" filter={filterName} />
-    <span className="unit-filter-button__name">
-      {t(`UNIT.FILTER.${invert(UnitFilters)[filterName]}`)}
-    </span>
+    <UnitFilterIcon
+      className="unit-filter-button__icon"
+      filter={filterName}
+      aria-hidden="true"
+    />
+    <span className="unit-filter-button__name">{message}</span>
     {showDropdownIndicator && <DropdownIndicator />}
   </Button>
 );

--- a/src/modules/unit/components/UnitFilterLabel.js
+++ b/src/modules/unit/components/UnitFilterLabel.js
@@ -1,28 +1,15 @@
 import React from 'react';
-import { translate } from 'react-i18next';
-
-const filterNameToLabel = (filterName) => {
-  switch (filterName) {
-    case 'sport':
-      return 'UNIT.FILTER_SPORT';
-    case 'status':
-      return 'UNIT.FILTER_STATUS';
-    default:
-      return '';
-  }
-};
 
 // eslint-disable-next-line react/prop-types
-const UnitFilterLabel = ({ filterName, t }) => {
-  const message = filterNameToLabel(filterName);
+const UnitFilterLabel = ({ message, id }) => {
   if (!message) {
     return null;
   }
   return (
-    <div className="unit-filter-label">
-      <span>{t(message)}:</span>
+    <div className="unit-filter-label" id={id}>
+      <span>{message}:</span>
     </div>
   );
 };
 
-export default translate()(UnitFilterLabel);
+export default UnitFilterLabel;

--- a/src/modules/unit/components/UnitFilterLabelButton.js
+++ b/src/modules/unit/components/UnitFilterLabelButton.js
@@ -5,21 +5,41 @@
 
 import React from 'react';
 import { translate } from 'react-i18next';
+import invert from 'lodash/invert';
 
+import { UnitFilters } from '../constants';
 import UnitFilterButton from './UnitFilterButton';
 import UnitFilterLabel from './UnitFilterLabel';
 
-const UnitFilterLabelButton = ({ filter, onAction, isActive, t }) => (
-  <div>
-    <UnitFilterLabel filterName={filter.name} />
-    <UnitFilterButton
-      t={t}
-      filterName={filter.active}
-      className={isActive ? 'active' : ''}
-      onClick={() => onAction(filter)}
-      showDropdownIndicator
-    />
-  </div>
-);
+const filterNameToLabel = (filterName) => {
+  switch (filterName) {
+    case 'sport':
+      return 'UNIT.FILTER_SPORT';
+    case 'status':
+      return 'UNIT.FILTER_STATUS';
+    default:
+      return '';
+  }
+};
+
+const UnitFilterLabelButton = ({ filter, onAction, isActive, t }) => {
+  const labelMessage = t(filterNameToLabel(filter.name));
+  const buttonMessage = t(`UNIT.FILTER.${invert(UnitFilters)[filter.active]}`);
+
+  return (
+    <div>
+      <UnitFilterLabel message={labelMessage} />
+      <UnitFilterButton
+        filterName={filter.active}
+        className={isActive ? 'active' : ''}
+        onClick={() => onAction(filter)}
+        showDropdownIndicator
+        message={buttonMessage}
+        aria-label={[buttonMessage, labelMessage].join(', ')}
+        aria-expanded={isActive}
+      />
+    </div>
+  );
+};
 
 export default translate()(UnitFilterLabelButton);

--- a/src/modules/unit/components/UnitFilters.js
+++ b/src/modules/unit/components/UnitFilters.js
@@ -12,6 +12,9 @@ import React from 'react';
 import { translate } from 'react-i18next';
 import { Grid, Row, Col } from 'react-bootstrap';
 import get from 'lodash/get';
+import invert from 'lodash/invert';
+
+import { UnitFilters } from '../constants';
 import UnitFilterButton from './UnitFilterButton';
 import UnitFilterLabelButton from './UnitFilterLabelButton';
 
@@ -36,6 +39,7 @@ const FilterOptionsRow = ({ t, className, filterName, options, onSelect }) => (
           t={t}
           filterName={option}
           onClick={() => onSelect(filterName, option)}
+          message={t(`UNIT.FILTER.${invert(UnitFilters)[option]}`)}
         />
       </Col>
     ))}


### PR DESCRIPTION
## Description

Adds a more complete description to the sub menu toggle button and improves aria support.

Also marks visual icons, which contain duplicate information, as hidden on screen reading devices.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-98](https://helsinkisolutionoffice.atlassian.net/browse/ULK-98)

## How Has This Been Tested?

This has been tested manually with Safari and VoiceOver.

## Manual Testing Instructions for Reviewers

With a screen reader

1. Access home page
2. Navigate to "choose sport" button
3. Expect to hear (for instance): "Skiing, Choose sport, collapsed, button"
4. Navigate to "choose condition" button
5. Expect to hear (for instance": "In all Conditions, Choose conditions, collapsed, button"
