### PR TITLE
ULK-100 | Fix unreachable show more link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 -   [Accessibility] Fix insufficient labels on sub menus
+-   [Accessibility] Fix unreachable show more link
 
 ## [1.1.2] - 2021-01-05
 

--- a/src/modules/common/enzymeHelpers.js
+++ b/src/modules/common/enzymeHelpers.js
@@ -7,12 +7,13 @@ import createStore from '../../bootstrap/createStore';
 import TranslationProvider from './components/translation/TranslationProvider';
 
 // eslint-disable-next-line import/prefer-default-export
-export const mount = async (element) => {
+export const mount = async (element, options) => {
   const store = await createStore();
 
   return enzymeMount(
     <Provider store={store}>
       <TranslationProvider>{element}</TranslationProvider>
-    </Provider>
+    </Provider>,
+    options
   );
 };

--- a/src/modules/unit/components/ListView.js
+++ b/src/modules/unit/components/ListView.js
@@ -67,7 +67,7 @@ UnitListItem.contextTypes = {
   getActiveLanguage: React.PropTypes.func,
 };
 
-class ListView extends Component {
+export class ListViewBase extends Component {
   static propTypes = {
     units: PropTypes.array,
     services: PropTypes.object,
@@ -83,6 +83,7 @@ class ListView extends Component {
 
     this.selectSortKey = this.selectSortKey.bind(this);
     this.loadMoreUnits = this.loadMoreUnits.bind(this);
+    this.handleLoadMoreClick = this.handleLoadMoreClick.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -143,6 +144,11 @@ class ListView extends Component {
     this.setState({ maxUnitCount: UNIT_BATCH_SIZE });
   }
 
+  handleLoadMoreClick(e) {
+    e.preventDefault();
+    this.loadMoreUnits();
+  }
+
   render() {
     const { services, openUnit, isLoading, t } = this.props;
     const { sortKey, maxUnitCount } = this.state;
@@ -180,7 +186,8 @@ class ListView extends Component {
                   cursor: 'pointer',
                   margin: '18px auto 10px',
                 }}
-                onClick={this.loadMoreUnits}
+                href
+                onClick={this.handleLoadMoreClick}
               >
                 {t('UNIT.SHOW_MORE')}
               </a>
@@ -192,8 +199,8 @@ class ListView extends Component {
   }
 }
 
-ListView.contextTypes = {
+ListViewBase.contextTypes = {
   getActiveLanguage: React.PropTypes.func,
 };
 
-export default translate()(ListView);
+export default translate()(ListViewBase);

--- a/src/modules/unit/components/__tests__/ListView.test.js
+++ b/src/modules/unit/components/__tests__/ListView.test.js
@@ -1,0 +1,148 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+
+import { mount } from '../../../common/enzymeHelpers';
+import ListView, { ListViewBase } from '../ListView';
+
+jest.mock('../../constants', () => ({
+  ...jest.requireActual('../../constants'),
+  UNIT_BATCH_SIZE: 1,
+}));
+
+const defaultProps = {
+  units: [
+    {
+      id: 53916,
+      name: {
+        fi: 'Mustavuori-Talosaari latu 5,5 km',
+        sv: 'Svarta backen-Husö skidspår 5,5 km',
+      },
+      street_address: {
+        fi: 'Niinisaarentie',
+        sv: 'Bastövägen',
+        en: 'Niinisaarentie',
+      },
+      www: {
+        fi:
+          'https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/liikunta/ulkoliikuntapaikat/ladut/',
+        sv:
+          'https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/liikunta/ulkoliikuntapaikat/ladut/',
+        en:
+          'https://www.hel.fi/helsinki/fi/kulttuuri-ja-vapaa-aika/liikunta/ulkoliikuntapaikat/ladut/',
+      },
+      phone: '+358 9 310 87906',
+      address_zip: '00960',
+      extensions: {
+        maintenance_group: 'kaikki',
+        maintenance_organization: 'helsinki',
+      },
+      municipality: 'helsinki',
+      services: [191],
+      location: {
+        type: 'Point',
+        coordinates: [25.171423, 60.234966],
+      },
+      connections: [],
+      observations: [
+        {
+          unit: 53916,
+          id: 51005,
+          property: 'ski_trail_condition',
+          time: '2021-01-04T14:52:08.546026+0200',
+          expiration_time: null,
+          name: {
+            fi: 'Lumenpuute',
+            sv: 'Snöbrist',
+            en: 'Lack of snow',
+          },
+          quality: 'unusable',
+          value: 'snowless',
+          primary: true,
+        },
+      ],
+    },
+    {
+      id: 54419,
+      name: {
+        fi: 'Mustavuoren latu 2,1 km',
+      },
+      street_address: {
+        fi: 'Mustavuori',
+        sv: 'Svartbäcken',
+        en: 'Mustavuori',
+      },
+      www: null,
+      phone: null,
+      address_zip: '00960',
+      extensions: {
+        maintenance_group: 'kaikki',
+        maintenance_organization: 'helsinki',
+      },
+      municipality: 'helsinki',
+      services: [191],
+      location: {
+        type: 'Point',
+        coordinates: [25.1415, 60.2288],
+      },
+      connections: [],
+      observations: [
+        {
+          unit: 54419,
+          id: 50985,
+          property: 'ski_trail_condition',
+          time: '2021-01-04T14:48:26.140649+0200',
+          expiration_time: null,
+          name: {
+            fi: 'Lumenpuute',
+            sv: 'Snöbrist',
+            en: 'Lack of snow',
+          },
+          quality: 'unusable',
+          value: 'snowless',
+          primary: true,
+        },
+      ],
+    },
+  ],
+  position: [1, 1],
+  maxUnitCount: 0,
+};
+
+const context = {
+  getActiveLanguage: () => 'fi',
+};
+
+const getWrapper = (props) =>
+  mount(<ListView {...defaultProps} {...props} />, {
+    context,
+    childContextTypes: context,
+  });
+
+describe('<ListView />', () => {
+  describe('show more link', () => {
+    const getShowMoreLink = (wrapper) =>
+      wrapper.find({ children: 'Näytä enemmän' });
+
+    it('should be rendered', async () => {
+      const wrapper = await getWrapper();
+
+      expect(getShowMoreLink(wrapper).length).toEqual(1);
+    });
+
+    it('should prevent default action and load more unit on click', async () => {
+      const mockEvent = {
+        preventDefault: jest.fn(),
+      };
+      const loadMoreUnitsSpy = jest
+        .spyOn(ListViewBase.prototype, 'loadMoreUnits')
+        .mockImplementation(() => {});
+      const wrapper = await getWrapper();
+      const showMoreLink = getShowMoreLink(wrapper);
+
+      showMoreLink.simulate('click', mockEvent);
+
+      expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+      expect(loadMoreUnitsSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds a href attribute to the show more link and cancel the default action. This makes the link focusable with the keyboard and screen reader.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-100](https://helsinkisolutionoffice.atlassian.net/browse/ULK-100)

## How Has This Been Tested?

I've added a unit test that checks the functionality of the link.

## Manual Testing Instructions for Reviewers

When using a screen reader

1. On the home page
2. Toggle on the list view
3. Browse to the load more link
4. Expect the link to be focusable
5. Expect clicking it to load more units
