### PR TITLE
ULK-112 | Add unique titles to pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 -   [Accessibility] Fix insufficient labels on sub menus
 -   [Accessibility] Fix unreachable show more link
+-   [Accessibility] Add unique titles to pages
 
 ## [1.1.2] - 2021-01-05
 

--- a/src/modules/common/components/Page.js
+++ b/src/modules/common/components/Page.js
@@ -1,13 +1,43 @@
-import React from 'react';
+// @flow
+import React, { Component, Node } from 'react';
 import PropTypes from 'prop-types';
 
 export const MAIN_CONTENT_ID = 'main-content';
 
-const Page = ({ children }) => (
-  <main id={MAIN_CONTENT_ID} className="main-content">
-    {children}
-  </main>
-);
+type Props = {
+  children: Node,
+  title: String,
+};
+
+class Page extends Component<Props> {
+  componentDidMount() {
+    this.updateTitle();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { title } = this.props;
+
+    if (title !== prevProps.title) {
+      this.updateTitle();
+    }
+  }
+
+  updateTitle() {
+    const { title } = this.props;
+
+    document.title = title;
+  }
+
+  render() {
+    const { children } = this.props;
+
+    return (
+      <main id={MAIN_CONTENT_ID} className="main-content">
+        {children}
+      </main>
+    );
+  }
+}
 
 Page.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/modules/common/components/__tests__/Page.test.js
+++ b/src/modules/common/components/__tests__/Page.test.js
@@ -14,4 +14,11 @@ describe('<Page />', () => {
       children
     );
   });
+
+  it('should set title', async () => {
+    const title = 'Title';
+    await getWrapper({ title, children: <div /> });
+
+    expect(document.title).toEqual(title);
+  });
 });

--- a/src/modules/home/components/HomeContainer.js
+++ b/src/modules/home/components/HomeContainer.js
@@ -13,6 +13,7 @@ import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
+import { translate } from 'react-i18next';
 import { fetchUnits } from '../../unit/actions';
 import { fetchServices } from '../../service/actions';
 import { setLocation } from '../../map/actions';
@@ -24,7 +25,7 @@ import * as fromUnit from '../../unit/selectors';
 import * as fromService from '../../service/selectors';
 import getLanguage from '../../language/selectors';
 import getIsLoading from '../selectors';
-import { getDefaultFilters } from '../../unit/helpers';
+import { getDefaultFilters, getAttr } from '../../unit/helpers';
 import MapView from '../../unit/components/MapView';
 import UnitBrowser from '../../unit/components/UnitBrowser';
 import SingleUnitModalContainer from '../../unit/components/SingleUnitModalContainer';
@@ -50,6 +51,7 @@ type Props = {
   mapCenter: number[],
   address: string,
   params: Object,
+  t: (string) => string,
 };
 
 type DefaultProps = {
@@ -110,6 +112,19 @@ class HomeContainer extends Component<DefaultProps, Props, void> {
   componentWillUnmount() {
     // TODO: Poll /observation, not /unit. => Normalize observations to store.
     // clearInterval(this.pollUnitsInterval);
+  }
+
+  getTitle() {
+    const { t, selectedUnit, activeLanguage } = this.props;
+    const title = [];
+
+    title.push(t('APP.NAME'));
+
+    if (selectedUnit) {
+      title.push(` - ${getAttr(selectedUnit.name, activeLanguage)}`);
+    }
+
+    return title.join('');
   }
 
   fetchUnits = () => {
@@ -175,7 +190,7 @@ class HomeContainer extends Component<DefaultProps, Props, void> {
       : getDefaultFilters();
 
     return (
-      <Page>
+      <Page title={this.getTitle()}>
         <div className="home">
           <UnitBrowser
             isLoading={isLoading}
@@ -247,5 +262,5 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
   );
 
 export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(HomeContainer)
+  connect(mapStateToProps, mapDispatchToProps)(translate()(HomeContainer))
 );


### PR DESCRIPTION
## Description

Adds logic which generate unique titles for each based on unit names.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-112](https://helsinkisolutionoffice.atlassian.net/browse/ULK-112)

## How Has This Been Tested?

I've expanded the unit tests for the `<Page />` component.

## Manual Testing Instructions for Reviewers

1. Select an unit
2. Expect title to change to a unique string
3. Close the unit modal
4. Expect title to change back
