### PR TITLE
ULK-104 | Fix insufficient contrast in primary color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] Fix insufficient labels on sub menus
 -   [Accessibility] Fix unreachable show more link
 -   [Accessibility] Add unique titles to pages
+-   [Accessibility] Fix insufficient contrast in primary color
 
 ## [1.1.2] - 2021-01-05
 

--- a/src/modules/common/_variables.scss
+++ b/src/modules/common/_variables.scss
@@ -7,7 +7,7 @@ $icon-size: 20px;
 
 // COLORS
 $ui-background: #77d5ed;
-$ui-content: #038ccc;
+$ui-content: #0072c6;
 $ui-enabled: #2d5c90;
 $ui-disabled: #61abd3;
 $ui-text: #ffffff;

--- a/src/modules/unit/components/_single-unit-modal.scss
+++ b/src/modules/unit/components/_single-unit-modal.scss
@@ -9,14 +9,14 @@
     margin: 0;
     width: 100%;
     height: 100%;
-    background: #038ccc;
+    background: #0072c6;
   }
 
   &-content {
     height: 100%;
     border-radius: 0;
     border: 0;
-    background: #038ccc;
+    background: #0072c6;
     color: #333333;
     padding: 10px 10px 0;
     overflow-y: scroll;
@@ -113,7 +113,7 @@
       border-radius: 0;
       border: 0;
       height: 100%;
-      background: #038ccc;
+      background: #0072c6;
       color: #333333;
     }
   }


### PR DESCRIPTION
## Description

Changes the primary colour to one that has enough contrast.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-104](https://helsinkisolutionoffice.atlassian.net/browse/ULK-104)

## How Has This Been Tested?

I've manually checked the views and used chrome's tooling to check that the contrast ratio now fills AA standards.

## Manual Testing Instructions for Reviewers

I don't really know what's the best approach here for testing. If you have the tools, for instance VisBug, you can use it to check the contrast for the white text on blue background.
