### PR TITLE
ULK-106 | Fix current address not read by screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] Fix unreachable show more link
 -   [Accessibility] Add unique titles to pages
 -   [Accessibility] Fix insufficient contrast in primary color
+-   [Accessibility] Fix current address not read by screen readers
 
 ## [1.1.2] - 2021-01-05
 

--- a/src/modules/unit/components/UnitBrowser.js
+++ b/src/modules/unit/components/UnitBrowser.js
@@ -66,7 +66,8 @@ const Header = translate()(
 );
 
 const AddressBar = ({ address, handleClick }, context) => (
-  <div
+  <button
+    type="button"
     className="address-bar__container"
     onClick={() => handleClick(address.location.coordinates.slice().reverse())}
   >
@@ -75,9 +76,10 @@ const AddressBar = ({ address, handleClick }, context) => (
       src={addressBarMarker}
       height="20px"
       width="16px"
+      alt=""
     />
     {address && getAddressToDisplay(address, context.getActiveLanguage())}
-  </div>
+  </button>
 );
 
 AddressBar.contextTypes = {

--- a/src/modules/unit/components/_unit-browser.scss
+++ b/src/modules/unit/components/_unit-browser.scss
@@ -99,6 +99,10 @@
     background: $ui-content;
     color: #fff;
     margin-top: $gap;
+    display: block;
+    border: none;
+    width: 100%;
+    text-align: left;
 
     &:hover {
       background: $ui-enabled;


### PR DESCRIPTION
## Description

Adds an empty alt tag to the location icon to mark it as decorative. Changes the wrapping DIV into a button so that it's accessible with keyboard.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-106](https://helsinkisolutionoffice.atlassian.net/browse/ULK-106)

## How Has This Been Tested?

I've tested this change manually with Safari and VoiceOver

## Manual Testing Instructions for Reviewers

With a screen reader

1. Navigate to current address element
2. Expect there to be no notice of a graphical element
3. Expect for the current address to be read
4. Expect for the element to be a button
