### PR TITLE
ULK-107 | Fix empty search returning nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] Fix insufficient contrast in primary color
 -   [Accessibility] Fix current address not read by screen readers
 -   [Accessibility] Fix sub menu options not being usable with screen reader or keyboard
+-   [Accessibility] Fix search returning nothing with an empty search
 
 ## [1.1.2] - 2021-01-05
 

--- a/src/modules/search/saga.js
+++ b/src/modules/search/saga.js
@@ -17,19 +17,28 @@ import {
   callApi,
   normalizeEntityResults,
 } from '../api/helpers';
+import { getFetchUnitsRequest } from '../unit/helpers';
 
 function* searchUnits({
   payload: { params },
 }: FetchAction): Generator<*, *, *> {
   let data = [];
+  let request = null;
+
   // Make search request only when there's input
   if (params.input && params.input.length) {
-    const request = createRequest(createUrl('search/', params));
-    const { bodyAsJson } = yield call(callApi, request);
-    data = bodyAsJson.results
-      ? normalizeEntityResults(bodyAsJson.results, new schema.Array(unitSchema))
-      : [];
+    request = createRequest(createUrl('search/', params));
+    // Otherwise get all units in order to comply with accessibility
+    // requirements
+  } else {
+    request = getFetchUnitsRequest(params);
   }
+
+  const { bodyAsJson } = yield call(callApi, request);
+  data = bodyAsJson.results
+    ? normalizeEntityResults(bodyAsJson.results, new schema.Array(unitSchema))
+    : [];
+
   // $FlowFixMe -> How to type annotate normalizeEntityResults to return array with arrayOf schema?
   yield put(receiveUnits(data));
 }

--- a/src/modules/unit/helpers.js
+++ b/src/modules/unit/helpers.js
@@ -6,7 +6,6 @@ import sortBy from 'lodash/sortBy';
 import head from 'lodash/head';
 import values from 'lodash/values';
 import upperFirst from 'lodash/upperFirst';
-import memoize from 'lodash/memoize';
 import get from 'lodash/get';
 
 import { LatLng, GeoJSON } from 'leaflet';
@@ -249,15 +248,7 @@ const _sortByDistance = (
   });
 };
 
-export const sortByDistance = memoize(
-  _sortByDistance,
-  (units, pos, leafletMap, filterString) => {
-    if (leafletMap === null || units.length === 0 || pos === undefined) {
-      return '0';
-    }
-    return `${filterString};${pos[0]};${pos[1]}`;
-  }
-);
+export const sortByDistance = _sortByDistance;
 
 export const sortByName = (units: Array<Object>, lang: ?string) =>
   sortBy(units, (unit) => getAttr(unit.name, lang));


### PR DESCRIPTION
## Description

Returning an empty result on an empty search was against accessibility guidelines.

This change aims to change the search procedure so that an empty search returns all units.

It was quite difficult to find the best approach to make this change even though it's relatively simple. I tried multiple approaches and deemed this to be the most simple one to implement.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-107](https://helsinkisolutionoffice.atlassian.net/browse/ULK-107)

## How Has This Been Tested?

I've tested this manually

## Manual Testing Instructions for Reviewers

1. Make a search
2. Expect to see correct results
3. Make an empty search
4. Expect to see all results
5. Make another search
6. Expect to see correct results 
