### PR TITLE
ULK-112 | Fix DOM order of units filter sub menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] Add unique titles to pages
 -   [Accessibility] Fix insufficient contrast in primary color
 -   [Accessibility] Fix current address not read by screen readers
+-   [Accessibility] Fix sub menu options not being usable with screen reader or keyboard
 
 ## [1.1.2] - 2021-01-05
 

--- a/src/modules/unit/components/UnitFilterLabelButton.js
+++ b/src/modules/unit/components/UnitFilterLabelButton.js
@@ -6,6 +6,7 @@
 import React from 'react';
 import { translate } from 'react-i18next';
 import invert from 'lodash/invert';
+import pick from 'lodash/pick';
 
 import { UnitFilters } from '../constants';
 import UnitFilterButton from './UnitFilterButton';
@@ -22,7 +23,7 @@ const filterNameToLabel = (filterName) => {
   }
 };
 
-const UnitFilterLabelButton = ({ filter, onAction, isActive, t }) => {
+const UnitFilterLabelButton = ({ filter, onAction, isActive, t, ...rest }) => {
   const labelMessage = t(filterNameToLabel(filter.name));
   const buttonMessage = t(`UNIT.FILTER.${invert(UnitFilters)[filter.active]}`);
 
@@ -37,6 +38,7 @@ const UnitFilterLabelButton = ({ filter, onAction, isActive, t }) => {
         message={buttonMessage}
         aria-label={[buttonMessage, labelMessage].join(', ')}
         aria-expanded={isActive}
+        {...pick(rest, ['aria-haspopup', 'aria-controls', 'id'])}
       />
     </div>
   );

--- a/src/modules/unit/components/UnitFilterOptionsWrapper.js
+++ b/src/modules/unit/components/UnitFilterOptionsWrapper.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Grid } from 'react-bootstrap';
+
+class UnitFilterOptionsWrapper extends React.Component<{ id: string }> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      height: 0,
+    };
+  }
+
+  componentDidMount() {
+    const { id } = this.props;
+
+    const menuWrapper = document.getElementById(id);
+    const wrapperHeight = menuWrapper.clientHeight;
+
+    this.setState({
+      height: wrapperHeight,
+    });
+  }
+
+  componentWillUnmount() {
+    this.setState({ height: 0 });
+  }
+
+  render() {
+    const { height } = this.state;
+
+    return (
+      <div>
+        <div style={{ height }} />
+        <Grid {...this.props} />
+      </div>
+    );
+  }
+}
+
+export default UnitFilterOptionsWrapper;

--- a/src/modules/unit/components/UnitFilters.js
+++ b/src/modules/unit/components/UnitFilters.js
@@ -17,6 +17,7 @@ import invert from 'lodash/invert';
 import { UnitFilters } from '../constants';
 import UnitFilterButton from './UnitFilterButton';
 import UnitFilterLabelButton from './UnitFilterLabelButton';
+import UnitFilterOptionsWrapper from './UnitFilterOptionsWrapper';
 
 type UnitFilterProps = {
   name: string,
@@ -87,7 +88,7 @@ const FilterOption = ({
         id={controlId}
       />
       {isActive && (
-        <Grid
+        <UnitFilterOptionsWrapper
           id={menuId}
           className="unit-filters__options-wrapper"
           tabIndex="-1"
@@ -118,7 +119,7 @@ const FilterOption = ({
               t={t}
             />
           )}
-        </Grid>
+        </UnitFilterOptionsWrapper>
       )}
     </div>
   );

--- a/src/modules/unit/components/UnitFilters.js
+++ b/src/modules/unit/components/UnitFilters.js
@@ -44,7 +44,6 @@ const FilterOptionsRow = ({
     {options.map((option) => (
       <Col className="unit-filters__option" xs={6} key={option}>
         <UnitFilterButton
-          t={t}
           filterName={option}
           onKeyDown={onKeyDown}
           onClick={() => onSelect(filterName, option)}

--- a/src/modules/unit/components/_unit-filters.scss
+++ b/src/modules/unit/components/_unit-filters.scss
@@ -24,6 +24,7 @@
     position: absolute;
     left: 0;
     right: 0;
+    bottom: 0;
     width: unset;
     margin-top: $gap;
 

--- a/src/modules/unit/components/_unit-filters.scss
+++ b/src/modules/unit/components/_unit-filters.scss
@@ -1,8 +1,14 @@
 .unit-filters {
   max-width: 100%;
   width: 100%;
+  position: relative;
   background: $ui-content;
   color: $ui-text;
+
+  &__filters {
+    position: unset;
+    width: unset;
+  }
 
   &__filters.container,
   &__options.container {
@@ -14,6 +20,16 @@
     padding: $gap;
   }
 
+  &__options-wrapper {
+    position: absolute;
+    left: 0;
+    right: 0;
+    width: unset;
+    margin-top: $gap;
+
+    background: $ui-disabled;
+  }
+
   &__options {
     background: $ui-disabled;
     color: $ui-text;
@@ -22,6 +38,10 @@
   &__options-separator {
     margin: 0 -5px;
     border-top: 1px solid $ui-enabled;
+  }
+
+  &__edit {
+    position: unset;
   }
 
   &__edit,


### PR DESCRIPTION
## Description

The dropdown filters under the search bar did not have a proper connection between the control and the options.

This PR changes the DOM order so that the options appear after the control, and adds aria attributes that should be helpful.

I had to include a bit of a hack in the options list. It was hard to implement without using `position: absolute`, but this came with the caveat that the options would no longer push the content that followed them downwards. Instead the options would hide content underneath them. In order to avoid this I implemented a mechanism where there's a placeholder component that's relatively positioned which then moves the content downwards. I could not come up with a better approach although I am sure there are some.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-112](https://helsinkisolutionoffice.atlassian.net/browse/ULK-112)

## How Has This Been Tested?

This has been tested manually with Safari and VoiceOver.

## Manual Testing Instructions for Reviewers

With a screen reader

1. Navigate to filter option for sport
2. Open the options list
3. Move forward with tab
4. Expect to be taken into options
5. Select an option
6. Expect focus to go back to the sport filter
7. Move onwards
8. Expect to hit the condition filter
9. Open it
10. Move onwards
11. Expect to navigate into condition options
12. Select an option
13. Expect for focus to be moved into condition filter control
