### PR TITLE
FIX | Add aria label to outbound links

### DIFF
--- a/src/modules/common/components/OutboundLink.js
+++ b/src/modules/common/components/OutboundLink.js
@@ -7,17 +7,20 @@ import SMIcon from '../../home/components/SMIcon';
 
 const TRANSLATION_PROPS = ['t', 'tReady', 'i18n', 'lng'];
 
-const OutboundLink = translate()(({ t, href, children, ...rest }) => (
-  <a
-    href={href}
-    target="_blank"
-    rel="noopener noreferrer"
-    {...omit(rest, TRANSLATION_PROPS)}
-  >
-    {children}{' '}
-    <SMIcon icon="outbound-link" title={t('OUTBOUND_LINK.DESCRIPTION')} />
-  </a>
-));
+const OutboundLink = translate()(({ t, href, children, ...rest }) => {
+  const name = t('OUTBOUND_LINK.DESCRIPTION');
+
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      {...omit(rest, TRANSLATION_PROPS)}
+    >
+      {children} <SMIcon icon="outbound-link" aria-label={name} title={name} />
+    </a>
+  );
+});
 
 OutboundLink.propTypes = {
   href: PropTypes.string.isRequired,


### PR DESCRIPTION
## Description

Some screen readers do not read the title attribute so we must also use
aria-label to be accessible. The title attribute is still useful
because it allows for instance desktop users to see what the icon
means.