### PR TITLE
ULK-111 | Improve service info button accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] Fix search returning nothing with an empty search
 -   [Accessibility] Add missing search landmark
 -   [Accessibility] Fix service info button for keyboard and screen reader users
+-   [Accessibility] Add contentinfo landmark
 
 ## [1.1.2] - 2021-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] Fix sub menu options not being usable with screen reader or keyboard
 -   [Accessibility] Fix search returning nothing with an empty search
 -   [Accessibility] Add missing search landmark
+-   [Accessibility] Fix service info button for keyboard and screen reader users
 
 ## [1.1.2] - 2021-01-05
 

--- a/src/modules/map/components/DropdownControl.js
+++ b/src/modules/map/components/DropdownControl.js
@@ -1,0 +1,136 @@
+import { PropTypes } from 'react';
+import ReactDOM from 'react-dom';
+import L from 'leaflet';
+import { MapControl } from 'react-leaflet';
+import pick from 'lodash/pick';
+
+export default class DropdownControl extends MapControl {
+  // eslint-disable-next-line react/static-property-placement
+  static propTypes = {
+    id: PropTypes.string,
+    handleClick: PropTypes.func,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.handleClick = this.handleClick.bind(this);
+    this.updateOptions = this.updateOptions.bind(this);
+  }
+
+  get wrapper() {
+    const { id } = this.props;
+
+    return document.getElementById(id);
+  }
+
+  get controlId() {
+    const { id } = this.props;
+
+    return `${id}-control`;
+  }
+
+  get control() {
+    return document.getElementById(this.controlId);
+  }
+
+  get optionsId() {
+    const { id } = this.props;
+
+    return `${id}-options`;
+  }
+
+  get optionsWrapper() {
+    return document.getElementById(this.optionsId);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { isOpen, activeLanguage } = this.props;
+    const ariaExpanded = this.props['aria-expanded'];
+
+    if (prevProps['aria-expanded'] !== ariaExpanded) {
+      this.syncProps(this.control, ['aria-expanded']);
+    }
+
+    if (
+      prevProps.isOpen !== isOpen ||
+      prevProps.activeLanguage !== activeLanguage
+    ) {
+      this.updateOptions();
+    }
+  }
+
+  componentWillMount() {
+    const { className, children } = this.props;
+
+    const control = L.control({
+      position: this.props.position || 'bottomright',
+    }); // see http://leafletjs.com/reference.html#control-positions for other positions
+
+    control.handleClick = this.handleClick;
+
+    // eslint-disable-next-line func-names
+    control.onAdd = () => {
+      const div = L.DomUtil.create('div', `custom-control ${className}`);
+      const button = L.DomUtil.create('button', 'custom-control-button', div);
+
+      this.syncProps(div, ['id']);
+      this.syncProps(button, ['aria-haspopup', 'aria-expanded']);
+
+      button.setAttribute('id', this.controlId);
+      button.setAttribute('aria-controls', this.optionsId);
+
+      L.DomEvent.on(button, 'mousedown dblclick', L.DomEvent.stopPropagation)
+        .on(button, 'click', L.DomEvent.stop)
+        .on(button, 'click', this.handleClick, control);
+
+      ReactDOM.render(children, button);
+
+      this.updateOptions();
+
+      return div;
+    };
+
+    this.leafletElement = control;
+  }
+
+  syncProps(element, propsList) {
+    const attributes = pick(this.props, propsList);
+
+    Object.entries(attributes).forEach(([attribute, value]) => {
+      element.setAttribute(attribute, value.toString());
+    });
+  }
+
+  makeOptionsWrapper() {
+    const element = document.createElement('div');
+
+    element.setAttribute('id', this.optionsId);
+    element.setAttribute('role', 'region');
+    element.setAttribute('aria-labelledby', this.controlId);
+
+    return element;
+  }
+
+  updateOptions() {
+    const { options, isOpen } = this.props;
+
+    if (isOpen) {
+      if (!this.optionsWrapper) {
+        this.wrapper.append(this.makeOptionsWrapper());
+      }
+
+      ReactDOM.render(options, this.optionsWrapper);
+    } else if (this.optionsWrapper) {
+      this.optionsWrapper.remove();
+    }
+  }
+
+  handleClick(event) {
+    L.DomEvent.stopPropagation(event);
+    event.stopPropagation();
+
+    // eslint-disable-next-line no-unused-expressions
+    this.props.handleClick && this.props.handleClick(event);
+  }
+}

--- a/src/modules/map/components/DropdownControl.js
+++ b/src/modules/map/components/DropdownControl.js
@@ -75,8 +75,9 @@ export default class DropdownControl extends MapControl {
       const button = L.DomUtil.create('button', 'custom-control-button', div);
 
       this.syncProps(div, ['id']);
-      this.syncProps(button, ['aria-haspopup', 'aria-expanded']);
+      div.setAttribute('role', 'contentinfo');
 
+      this.syncProps(button, ['aria-haspopup', 'aria-expanded']);
       button.setAttribute('id', this.controlId);
       button.setAttribute('aria-controls', this.optionsId);
 

--- a/src/modules/unit/components/MapView.js
+++ b/src/modules/unit/components/MapView.js
@@ -23,6 +23,7 @@ import FeedbackModal from './FeedbackModal';
 import { View } from './View';
 import Logo from '../../home/components/Logo';
 import Control from '../../map/components/Control';
+import DropdownControl from '../../map/components/DropdownControl';
 import { mobileBreakpoint } from '../../common/constants';
 import { SUPPORTED_LANGUAGES } from '../../language/constants';
 import {
@@ -40,6 +41,7 @@ import UserLocationMarker from '../../map/components/UserLocationMarker';
 import { isRetina } from '../../common/helpers';
 import OutboundLink from '../../common/components/OutboundLink';
 import LanguageChanger from './LanguageChanger';
+import TranslationProvider from '../../common/components/translation/TranslationProvider';
 
 class MapView extends Component {
   static propTypes = {
@@ -193,23 +195,29 @@ class MapView extends Component {
               changeLanguage={changeLanguage}
             />
           )}
-          {menuOpen ? (
-            <InfoMenu
-              t={t}
-              isMobile={isMobile}
-              openAboutModal={this.openAboutModal}
-              openFeedbackModal={this.openFeedbackModal}
-              activeLanguage={activeLanguage}
-              changeLanguage={changeLanguage}
-            />
-          ) : null}
-          <Control
+          <DropdownControl
+            id="info-dropdown"
             handleClick={this.toggleMenu}
             className="leaflet-control-info"
             position={isMobile ? 'bottomleft' : 'topright'}
+            aria-haspopup="true"
+            aria-expanded={menuOpen}
+            activeLanguage={activeLanguage}
+            isOpen={menuOpen}
+            options={
+              <InfoMenu
+                store={this.context.store}
+                t={t}
+                isMobile={isMobile}
+                openAboutModal={this.openAboutModal}
+                openFeedbackModal={this.openFeedbackModal}
+                activeLanguage={activeLanguage}
+                changeLanguage={changeLanguage}
+              />
+            }
           >
-            <SMIcon icon="info" />
-          </Control>
+            <SMIcon icon="info" aria-label={t('APP.ABOUT')} />
+          </DropdownControl>
         </Map>
         <Logo />
         {this.state.aboutModalOpen ? (
@@ -223,6 +231,10 @@ class MapView extends Component {
   }
 }
 
+MapView.contextTypes = {
+  store: PropTypes.object.isRequired,
+};
+
 export default translate(null, { withRef: true })(MapView);
 
 const InfoMenu = ({
@@ -232,39 +244,41 @@ const InfoMenu = ({
   isMobile,
   activeLanguage,
   changeLanguage,
+  store,
 }) => (
-  <div className="info-menu">
-    <InfoMenuItem icon="info" handleClick={openFeedbackModal} t={t}>
-      {t('MAP.INFO_MENU.GIVE_FEEDBACK')}
-    </InfoMenuItem>
-    <InfoMenuItem icon="info" handleClick={openAboutModal}>
-      {t('MAP.INFO_MENU.ABOUT_SERVICE')}
-    </InfoMenuItem>
-    <InfoMenuItem handleClick={() => null}>
-      <OutboundLink href="http://osm.org/copyright" style={{ padding: 1 }}>
-        &copy;
-        {t('MAP.ATTRIBUTION')}{' '}
-      </OutboundLink>
-    </InfoMenuItem>
-    {isMobile && Object.keys(SUPPORTED_LANGUAGES).length > 1 && (
-      <InfoMenuItem handleClick={() => null}>
-        <strong>{t('MAP.INFO_MENU.CHOOSE_LANGUAGE')}</strong>
-        <LanguageChanger
-          style={{ position: 'static' }}
-          activeLanguage={activeLanguage}
-          changeLanguage={changeLanguage}
-          isMobile={isMobile}
-        />
+  <TranslationProvider store={store}>
+    <div className="info-menu">
+      <InfoMenuItem icon="info" handleClick={openFeedbackModal} t={t}>
+        {t('MAP.INFO_MENU.GIVE_FEEDBACK')}
       </InfoMenuItem>
-    )}
-  </div>
+      <InfoMenuItem icon="info" handleClick={openAboutModal}>
+        {t('MAP.INFO_MENU.ABOUT_SERVICE')}
+      </InfoMenuItem>
+      <OutboundLink className="info-menu-item" href="http://osm.org/copyright">
+        &copy; {t('MAP.ATTRIBUTION')}{' '}
+      </OutboundLink>
+      {isMobile && Object.keys(SUPPORTED_LANGUAGES).length > 1 && (
+        <InfoMenuItem handleClick={() => null}>
+          <strong>{t('MAP.INFO_MENU.CHOOSE_LANGUAGE')}</strong>
+          <LanguageChanger
+            style={{ position: 'static' }}
+            activeLanguage={activeLanguage}
+            changeLanguage={changeLanguage}
+            isMobile={isMobile}
+          />
+        </InfoMenuItem>
+      )}
+    </div>
+  </TranslationProvider>
 );
 
 const InfoMenuItem = ({ children, handleClick, icon }) => (
-  <div className="info-menu-item" onClick={handleClick}>
-    {icon ? <SMIcon icon={icon} style={{ paddingRight: 2 }} /> : null}
+  <button type="button" className="info-menu-item" onClick={handleClick}>
+    {icon ? (
+      <SMIcon icon={icon} style={{ paddingRight: 2 }} aria-hidden="true" />
+    ) : null}
     {children}
-  </div>
+  </button>
 );
 
 const AboutModal = ({ closeModal, t }) => (

--- a/src/modules/unit/components/_map-view.scss
+++ b/src/modules/unit/components/_map-view.scss
@@ -64,8 +64,16 @@
   line-height: 24px;
 
   &-item {
-    &:hover {
-      background: $list-view-item-hover;
+    padding: 3px 6px;
+
+    text-align: left;
+
+    border: none;
+    background: transparent;
+
+    &:hover,
+    &:active {
+      background: $list-view-item-hover !important;
       cursor: pointer;
     }
     a {


### PR DESCRIPTION
## Description

Previously the info button was not usable with keyboard or screen readers. After this change it should be usable with both.

DOM order was changed so that the option list comes right after the info toggle button.

Missing aria definitions were added.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-111](https://helsinkisolutionoffice.atlassian.net/browse/ULK-111)

## How Has This Been Tested?

I've tested this manually.

## Manual Testing Instructions for Reviewers

With a screen reader

1. Access the info button
2. Expect for it to have a name
3. Open it
4. Tab forward
5. Expect to land on the options
6. Expect each option to be focusable
7. Expect each option to have an accessible name that matches with the visual representation
8. Expect decorative icons to be hidden

The content that can be opened through the menu won't be accessible after this change.
