### PR TITLE
ULK-96 | Hide map markers with aria-hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 -   [Accessibility] Add missing search landmark
 -   [Accessibility] Fix service info button for keyboard and screen reader users
 -   [Accessibility] Add contentinfo landmark
+-   [Accessibility] Hide map markers from some screen reader navigation approaches so that the application is easier to browse through
 
 ## [1.1.2] - 2021-01-05
 

--- a/src/modules/map/AriaHiddenIcon.js
+++ b/src/modules/map/AriaHiddenIcon.js
@@ -1,0 +1,9 @@
+import { Icon } from 'leaflet';
+
+export default Icon.extend({
+  _setIconStyles(img, name) {
+    Icon.prototype._setIconStyles.call(this, img, name);
+
+    img.setAttribute('aria-hidden', true);
+  },
+});

--- a/src/modules/map/components/UserLocationMarker.js
+++ b/src/modules/map/components/UserLocationMarker.js
@@ -10,16 +10,16 @@ import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Marker } from 'react-leaflet';
-import { Icon } from 'leaflet';
 import { setLocation } from '../actions';
 import { getLocation } from '../selectors';
 import latLngToArray from '../helpers';
+import AriaHiddenIcon from '../AriaHiddenIcon';
 
 const iconUrl = require('@assets/markers/location.png');
 const iconRetinaUrl = require('@assets/markers/location@2x.png');
 
 const createIcon = () =>
-  new Icon({
+  new AriaHiddenIcon({
     iconUrl,
     iconRetinaUrl,
     iconSize: [12, 23],

--- a/src/modules/unit/components/UnitMarker.js
+++ b/src/modules/unit/components/UnitMarker.js
@@ -10,10 +10,10 @@
 
 import React, { Component } from 'react';
 import { Marker } from 'react-leaflet';
-import { Icon } from 'leaflet';
 import { getUnitIcon, getUnitPosition, getUnitSport } from '../helpers';
 import { UNIT_ICON_WIDTH, UnitFilters } from '../constants';
 import { MAX_ZOOM } from '../../map/constants';
+import AriaHiddenIcon from '../../map/AriaHiddenIcon';
 import UnitPopup from './UnitPopup';
 
 const POPUP_OFFSET = 4;
@@ -53,7 +53,7 @@ class UnitMarker extends Component {
     const iconHeight = this.getIconHeight(icon, this.props.zoomLevel);
     const anchorHeight = this._getAnchorHeight(iconHeight, unit);
 
-    return new Icon({
+    return new AriaHiddenIcon({
       iconUrl: icon.url,
       iconRetinaUrl: icon.retinaUrl,
       iconSize: [iconWidth, iconHeight],


### PR DESCRIPTION
## Description

Adds aria-hidden definition to map markers.

This is against best practises because we are hiding focusable content. It'll still be accessible for screen reader users who use tab to navigate. This approach was advised in the accessibility report.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-96](https://helsinkisolutionoffice.atlassian.net/browse/ULK-97)

## How Has This Been Tested?

I've tested this manually with Safari and VoiceOver.

## Manual Testing Instructions for Reviewers

With a screen reader

1. Tab through the search UI until you hit the map markers
2. Expect markers to be focused while hearing nothgin

1. Move through the UI using text navigation (<kbd>Ctrl</kbd> + <kbd>Opt</kbd> + <kbd>Right Arrow</kbd> / <kbd>Left Arrow</kbd>)
2. Expect markers to be ignored
