### PR TITLE
ULK-118 | Add link to palvelukartta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+-   Link to palvelukartta in unit details view
+
 ### Fixed
 
 -   [Accessibility] Fix insufficient labels on sub menus

--- a/locales/en.json
+++ b/locales/en.json
@@ -60,12 +60,13 @@
     "LIGHTING": "Lighting",
     "SKIING_TECHNIQUE": "Form of skiing",
     "TEMPERATURE": "Temperature",
-    "ROUTE_HERE": "Route to here",
+    "LINKS": "Links",
     "GET_ROUTE": "Get route to here",
     "NOTICE": "Notice",
     "WATER_TEMPERATURE": "Water temperature",
     "WATER_TEMPERATURE_SENSOR": "Water temperature sensor",
-    "CLOSE": "Close"
+    "CLOSE": "Close",
+    "SEE_ON_SERVICE_MAP": "See on Palvelukartta"
   },
   "VIEW": {
     "POPUP": {

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -60,12 +60,13 @@
     "LIGHTING": "Valaistus",
     "SKIING_TECHNIQUE": "Hiihtotekniikka",
     "TEMPERATURE": "Lämpötila",
-    "ROUTE_HERE": "Reitti tänne",
+    "LINKS": "Linkit",
     "GET_ROUTE": "Hae reitti tänne",
     "NOTICE": "Tiedote",
     "WATER_TEMPERATURE": "Veden lämpötila",
     "WATER_TEMPERATURE_SENSOR": "Uimarantasensori",
-    "CLOSE": "Sulje"
+    "CLOSE": "Sulje",
+    "SEE_ON_SERVICE_MAP": "Katso palvelukartalla"
   },
   "VIEW": {
     "POPUP": {

--- a/locales/sv.json
+++ b/locales/sv.json
@@ -60,12 +60,13 @@
     "LIGHTING": "Belysning",
     "SKIING_TECHNIQUE": "Åkstil",
     "TEMPERATURE": "Temperatur",
-    "ROUTE_HERE": "Väg hit",
+    "LINKS": "Länkar",
     "GET_ROUTE": "Väg hit",
     "NOTICE": "Meddelande",
     "WATER_TEMPERATURE": "Vattnets temperatur",
     "WATER_TEMPERATURE_SENSOR": "Vattentemperatur sensor",
-    "CLOSE": "Stänga"
+    "CLOSE": "Stänga",
+    "SEE_ON_SERVICE_MAP": "Se på Palvelukartta"
   },
   "VIEW": {
     "POPUP": {

--- a/src/modules/unit/components/SingleUnitModalContainer.js
+++ b/src/modules/unit/components/SingleUnitModalContainer.js
@@ -26,6 +26,7 @@ import {
   getOpeningHours,
   getObservationTime,
   createReittiopasUrl,
+  createPalvelukarttaUrl,
 } from '../helpers';
 import getServiceName from '../../service/helpers';
 import OutboundLink from '../../common/components/OutboundLink';
@@ -173,9 +174,22 @@ const NoticeInfo = ({ unit, t, activeLang }) => {
   ) : null;
 };
 
-const LocationRoute = ({ routeUrl, t }) => (
-  <ModalBodyBox title={t('MODAL.ROUTE_HERE')}>
-    <OutboundLink href={routeUrl}>{t('MODAL.GET_ROUTE')}</OutboundLink>
+const LocationRoute = ({ routeUrl, t, palvelukarttaUrl }) => (
+  <ModalBodyBox title={t('MODAL.LINKS')}>
+    <ul className="modal-body-list">
+      {routeUrl && (
+        <li>
+          <OutboundLink href={routeUrl}>{t('MODAL.GET_ROUTE')}</OutboundLink>
+        </li>
+      )}
+      {palvelukarttaUrl && (
+        <li>
+          <OutboundLink href={palvelukarttaUrl}>
+            {t('MODAL.SEE_ON_SERVICE_MAP')}
+          </OutboundLink>
+        </li>
+      )}
+    </ul>
   </ModalBodyBox>
 );
 
@@ -255,6 +269,7 @@ export const SingleUnitModalBody = ({
   shouldShowInfo,
   t,
   temperatureObservation,
+  palvelukarttaUrl,
 }) =>
   currentUnit && !isLoading ? (
     <Modal.Body>
@@ -279,7 +294,13 @@ export const SingleUnitModalBody = ({
           activeLang={getActiveLanguage}
         />
       )}
-      {routeUrl && <LocationRoute t={t} routeUrl={routeUrl} />}
+      {(routeUrl || palvelukarttaUrl) && (
+        <LocationRoute
+          t={t}
+          routeUrl={routeUrl}
+          palvelukarttaUrl={palvelukarttaUrl}
+        />
+      )}
     </Modal.Body>
   ) : null;
 
@@ -321,6 +342,8 @@ class SingleUnitModalContainer extends Component {
       getObservation(currentUnit, 'live_swimming_water_temperature');
     const routeUrl =
       currentUnit && createReittiopasUrl(currentUnit, getActiveLanguage());
+    const palvelukarttaUrl =
+      currentUnit && createPalvelukarttaUrl(currentUnit, getActiveLanguage());
 
     return (
       <div>
@@ -347,6 +370,7 @@ class SingleUnitModalContainer extends Component {
             shouldShowInfo={this.shouldShowInfo}
             t={t}
             temperatureObservation={temperatureObservation}
+            palvelukarttaUrl={palvelukarttaUrl}
           />
         </Modal>
       </div>

--- a/src/modules/unit/components/_single-unit-modal.scss
+++ b/src/modules/unit/components/_single-unit-modal.scss
@@ -85,6 +85,16 @@
         display: inline-block;
       }
     }
+
+    &-list {
+      padding: 0;
+      margin: 0;
+      list-style-type: none;
+
+      & > li {
+        margin-bottom: 1rem;
+      }
+    }
   }
 
   &-close-button {

--- a/src/modules/unit/helpers.js
+++ b/src/modules/unit/helpers.js
@@ -85,6 +85,9 @@ export const createReittiopasUrl = (unit, lang) => {
   return url;
 };
 
+export const createPalvelukarttaUrl = (unit, lang) =>
+  `https://palvelukartta.hel.fi/${lang}/unit/${unit.id}`;
+
 export const getUnitSport = (unit: Object) => {
   if (unit.services && unit.services.length) {
     // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
## Description

Renames the directions sections into "links" section and adds a link to Palvelukartta into it.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-118](https://helsinkisolutionoffice.atlassian.net/browse/ULK-118)

## How Has This Been Tested?

I've tested this manually.

## Manual Testing Instructions for Reviewers

1. Access a unit
2. Expect to see links section
3. Expect it to contain a link into Palvelukartta
4. Expect the link to point to the same localisation of Palvelukartta as is selected in Ulkoliikuntakartta
