### PR TITLE
ULK-119 | Preserve the zoom level when an unit is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+-   [#73](https://github.com/City-of-Helsinki/outdoors-sports-map/pull/73) Preserve zoom level when opening unit on mobile (@vaahtokarkki)
+
+### Fixed
+
+-   [#73](https://github.com/City-of-Helsinki/outdoors-sports-map/pull/73) Mobile unit focus hiding point of interest under unit modal (@vaahtokarkki)
+
 ## [1.1.5] - 2021-02-08
 
 ### Added

--- a/src/modules/unit/components/MapView.js
+++ b/src/modules/unit/components/MapView.js
@@ -81,7 +81,7 @@ class MapView extends Component {
       this.refs.map.leafletElement.setView(location);
     } else {
       // On mobile we want to move the map 250px down from the center, so the
-      // awkwardly big info box does not hide the selected unit.
+      // big info box does not hide the selected unit.
       const pixelLocation = this.refs.map.leafletElement.latLngToContainerPoint(
         location
       );

--- a/src/modules/unit/components/MapView.js
+++ b/src/modules/unit/components/MapView.js
@@ -77,15 +77,16 @@ class MapView extends Component {
 
   centerMapToUnit = (unit: Object) => {
     const location = getUnitPosition(unit);
-    if (!this.state.isMobile)
-      return this.refs.map.leafletElement.setView(location)
-
-    // On mobile we want to move the map ~250px down from the center, so the
-    // awkwardly big info box does not hide the selected unit.
-    const pixelLocation = this.refs.map.leafletElement.latLngToContainerPoint(location)
-    pixelLocation.y -= 250
-    const adjustedCenter = this.refs.map.leafletElement.containerPointToLatLng(pixelLocation)
-    this.refs.map.leafletElement.setView(adjustedCenter);
+    if (!this.state.isMobile) {
+      this.refs.map.leafletElement.setView(location)
+    } else {
+      // On mobile we want to move the map 250px down from the center, so the
+      // awkwardly big info box does not hide the selected unit.
+      const pixelLocation = this.refs.map.leafletElement.latLngToContainerPoint(location)
+      pixelLocation.y -= 250
+      const adjustedCenter = this.refs.map.leafletElement.containerPointToLatLng(pixelLocation)
+      this.refs.map.leafletElement.setView(adjustedCenter);
+    }
   };
 
   handleZoom = () => {

--- a/src/modules/unit/components/MapView.js
+++ b/src/modules/unit/components/MapView.js
@@ -76,18 +76,16 @@ class MapView extends Component {
   }
 
   centerMapToUnit = (unit: Object) => {
-    if (this.state.isMobile) {
-      const location = getUnitPosition(unit);
-      location[0] += 0.035;
-      location[1] -= 0.005;
-      // For some reason could not use reverse here so had to do this weird way.
-      this.refs.map.leafletElement.setView(location, DEFAULT_ZOOM);
-    } else {
-      const location = getUnitPosition(unit);
-      location[1] -= 0.07;
+    const location = getUnitPosition(unit);
+    if (!this.state.isMobile)
+      return this.refs.map.leafletElement.setView(location)
 
-      this.refs.map.leafletElement.setView(location, DEFAULT_ZOOM);
-    }
+    // On mobile we want to move the map ~250px down from the center, so the
+    // awkwardly big info box does not hide the selected unit.
+    const pixelLocation = this.refs.map.leafletElement.latLngToContainerPoint(location)
+    pixelLocation.y -= 250
+    const adjustedCenter = this.refs.map.leafletElement.containerPointToLatLng(pixelLocation)
+    this.refs.map.leafletElement.setView(adjustedCenter);
   };
 
   handleZoom = () => {

--- a/src/modules/unit/components/MapView.js
+++ b/src/modules/unit/components/MapView.js
@@ -78,13 +78,17 @@ class MapView extends Component {
   centerMapToUnit = (unit: Object) => {
     const location = getUnitPosition(unit);
     if (!this.state.isMobile) {
-      this.refs.map.leafletElement.setView(location)
+      this.refs.map.leafletElement.setView(location);
     } else {
       // On mobile we want to move the map 250px down from the center, so the
       // awkwardly big info box does not hide the selected unit.
-      const pixelLocation = this.refs.map.leafletElement.latLngToContainerPoint(location)
-      pixelLocation.y -= 250
-      const adjustedCenter = this.refs.map.leafletElement.containerPointToLatLng(pixelLocation)
+      const pixelLocation = this.refs.map.leafletElement.latLngToContainerPoint(
+        location
+      );
+      pixelLocation.y -= 250;
+      const adjustedCenter = this.refs.map.leafletElement.containerPointToLatLng(
+        pixelLocation
+      );
       this.refs.map.leafletElement.setView(adjustedCenter);
     }
   };

--- a/src/modules/unit/components/MapView.js
+++ b/src/modules/unit/components/MapView.js
@@ -77,14 +77,20 @@ class MapView extends Component {
 
   centerMapToUnit = (unit: Object) => {
     const location = getUnitPosition(unit);
+    const pixelLocation = this.refs.map.leafletElement.latLngToContainerPoint(
+      location
+    );
     if (!this.state.isMobile) {
-      this.refs.map.leafletElement.setView(location);
+      // Offset by half the width of unit modal in order to center focus
+      // on the visible map
+      pixelLocation.x -= 200;
+      const adjustedCenter = this.refs.map.leafletElement.containerPointToLatLng(
+        pixelLocation
+      );
+      this.refs.map.leafletElement.setView(adjustedCenter);
     } else {
       // On mobile we want to move the map 250px down from the center, so the
       // big info box does not hide the selected unit.
-      const pixelLocation = this.refs.map.leafletElement.latLngToContainerPoint(
-        location
-      );
       pixelLocation.y -= 250;
       const adjustedCenter = this.refs.map.leafletElement.containerPointToLatLng(
         pixelLocation


### PR DESCRIPTION
## Description

Refactor `centerMapToUnit` method to move the new center location by 250px down. This is achieved with Leaflet's built-in functionality. 

## Context

When a unit is selected the map is always zoomed to the default zoom level. This is on mobile really annoying as one needs often to zoom in multiple levels to be able to select anything from the map. This makes the app hard to use on mobile.

## How Has This Been Tested?

Tested on local dev environment, with desktop and mobile.

Original PR #71 (@vaahtokarkki)
[ULK-119](https://helsinkisolutionoffice.atlassian.net/browse/ULK-119)

## Manual Testing Instructions for Reviewers

Spin up dev environment and click some units. On mobile, make sure that the unit is visible and not under the info box.

## Screenshots

