### PR TITLE
ULK-134 | Include language in the url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,9 @@ import 'regenerator-runtime/runtime';
 /* eslint-enable import/no-extraneous-dependencies */
 import { createElement } from 'react';
 import { render } from 'react-dom';
-import { createBrowserHistory } from 'history';
 
 import './index.scss';
+import history from './modules/common/history';
 import Root from './modules/common/components/Root';
-
-const history = createBrowserHistory();
 
 render(createElement(Root, { history }), document.getElementById('root'));

--- a/src/modules/common/components/App.js
+++ b/src/modules/common/components/App.js
@@ -6,10 +6,14 @@ import type { ContextRouter } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { languageParam } from '../../language/constants';
+import useScrollToTop from '../hooks/useScrollToTop';
+import ResetFocus from './ResetFocus';
 import JumpLink from './JumpLink';
 import LanguageAwareRoutes from './LanguageAwareRoutes';
 
 const App = () => {
+  useScrollToTop();
+
   const {
     i18n: {
       languages: [language],
@@ -18,6 +22,7 @@ const App = () => {
 
   return (
     <div id="app-wrapper">
+      <ResetFocus />
       <JumpLink />
       <Switch>
         <Route path={`/${languageParam}`} component={LanguageAwareRoutes} />

--- a/src/modules/common/components/App.js
+++ b/src/modules/common/components/App.js
@@ -1,24 +1,34 @@
+// @flow
+
 import React from 'react';
-import PropTypes from 'prop-types';
-import { Router, Route } from 'react-router-dom';
+import { Route, Switch, Redirect } from 'react-router-dom';
+import type { ContextRouter } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
-import HomeContainer from '../../home/components/HomeContainer';
-import TranslationProvider from './translation/TranslationProvider';
+import { languageParam } from '../../language/constants';
 import JumpLink from './JumpLink';
+import LanguageAwareRoutes from './LanguageAwareRoutes';
 
-const App = ({ history }) => (
-  <TranslationProvider>
+const App = () => {
+  const {
+    i18n: {
+      languages: [language],
+    },
+  } = useTranslation();
+
+  return (
     <div id="app-wrapper">
       <JumpLink />
-      <Router history={history}>
-        <Route path="/" component={HomeContainer} />
-      </Router>
+      <Switch>
+        <Route path={`/${languageParam}`} component={LanguageAwareRoutes} />
+        <Route
+          render={(props: ContextRouter) => (
+            <Redirect to={`/${language}${props.location.pathname}`} />
+          )}
+        />
+      </Switch>
     </div>
-  </TranslationProvider>
-);
-
-App.propTypes = {
-  history: PropTypes.objectOf(PropTypes.any).isRequired,
+  );
 };
 
 export default App;

--- a/src/modules/common/components/LanguageAwareRoutes.js
+++ b/src/modules/common/components/LanguageAwareRoutes.js
@@ -1,0 +1,37 @@
+// @flow
+
+// $FlowIgnore
+import React, { useEffect } from 'react';
+import {
+  Route,
+  // $FlowIgnore
+  useRouteMatch,
+} from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+import HomeContainer from '../../home/components/HomeContainer';
+import { languageParam } from '../../language/constants';
+
+function getRouteLanguage(match: ?Object) {
+  if (!match) {
+    return null;
+  }
+
+  return match.params.language;
+}
+
+const LanguageAwareRoutes = () => {
+  const { i18n } = useTranslation();
+  const match = useRouteMatch();
+
+  const routeLanguage = getRouteLanguage(match);
+
+  useEffect(() => {
+    // Sync language with i18next in case it is changed by changing the url
+    i18n.changeLanguage(routeLanguage);
+  }, [routeLanguage]);
+
+  return <Route path={`/${languageParam}`} component={HomeContainer} />;
+};
+
+export default LanguageAwareRoutes;

--- a/src/modules/common/components/LanguageAwareRoutes.js
+++ b/src/modules/common/components/LanguageAwareRoutes.js
@@ -21,15 +21,22 @@ function getRouteLanguage(match: ?Object) {
 }
 
 const LanguageAwareRoutes = () => {
-  const { i18n } = useTranslation();
+  const {
+    i18n,
+    i18n: {
+      languages: [language],
+    },
+  } = useTranslation();
   const match = useRouteMatch();
 
   const routeLanguage = getRouteLanguage(match);
 
   useEffect(() => {
     // Sync language with i18next in case it is changed by changing the url
-    i18n.changeLanguage(routeLanguage);
-  }, [routeLanguage]);
+    if (language !== routeLanguage) {
+      i18n.changeLanguage(routeLanguage);
+    }
+  }, [routeLanguage, language]);
 
   return <Route path={`/${languageParam}`} component={HomeContainer} />;
 };

--- a/src/modules/common/components/Link.js
+++ b/src/modules/common/components/Link.js
@@ -1,0 +1,51 @@
+// @flow
+
+import React from 'react';
+import type { Node } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { LocationShape } from 'react-router-dom';
+import { Link as RRLink } from 'react-router-dom';
+
+import * as PathUtils from '../pathUtils';
+
+export function getToWithLanguage(to: string | LocationShape, lang: string) {
+  if (typeof to === 'function') {
+    return PathUtils.getLocationFactoryWithLanguage(to, lang);
+  }
+
+  if (typeof to === 'string') {
+    return PathUtils.getPathnameWithLanguage(to, lang);
+  }
+
+  return PathUtils.getLocationWithLanguage(to, lang);
+}
+
+type Props = {
+  className?: string,
+  to: string | LocationShape,
+  replace?: boolean,
+  children?: Node,
+} & {
+  lang?: false | string,
+};
+
+function Link({ to, lang: userLang, ...rest }: Props) {
+  const {
+    i18n: {
+      languages: [language],
+    },
+  } = useTranslation();
+
+  const lang = userLang !== undefined ? userLang : language;
+  // Allow the language interpolation to be ignored in case the language
+  // is already available in the url or if it's not needed.
+  const injectedTo =
+    typeof lang === 'boolean' && lang === false
+      ? to
+      : getToWithLanguage(to, lang);
+
+  // $FlowIgnore
+  return <RRLink {...rest} to={injectedTo} />;
+}
+
+export default Link;

--- a/src/modules/common/components/ResetFocus.js
+++ b/src/modules/common/components/ResetFocus.js
@@ -1,0 +1,26 @@
+// @flow
+
+// $FlowIgnore
+import React, { useRef } from 'react';
+
+import useReactRouterNavigationSideEffect from '../hooks/useReactRouterNavigationSideEffect';
+
+/**
+ * Ensure that browser focus is set to body when navigating using
+ * <Link> from react-router-dom.
+ */
+const ResetFocus = () => {
+  const elementRef = useRef(null);
+
+  useReactRouterNavigationSideEffect(() => {
+    const element = elementRef.current;
+
+    if (element) {
+      element.focus();
+    }
+  });
+
+  return <div ref={elementRef} tabIndex={-1} />;
+};
+
+export default ResetFocus;

--- a/src/modules/common/components/Root.js
+++ b/src/modules/common/components/Root.js
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/es/integration/react';
+import { Router } from 'react-router-dom';
+
 import createStore from '../../../bootstrap/createStore';
+import TranslationProvider from './translation/TranslationProvider';
 import App from './App';
 
 const { persistor, store } = createStore();
@@ -10,7 +13,11 @@ const { persistor, store } = createStore();
 const Root = ({ history }) => (
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>
-      <App history={history} />
+      <TranslationProvider>
+        <Router history={history}>
+          <App />
+        </Router>
+      </TranslationProvider>
     </PersistGate>
   </Provider>
 );

--- a/src/modules/common/constants.js
+++ b/src/modules/common/constants.js
@@ -38,7 +38,3 @@ export type AppState = {
 };
 
 export type QueryValue = string | Array<string>;
-
-export const routerPaths = {
-  singleUnit: '/unit/:unitId',
-};

--- a/src/modules/common/helpers.js
+++ b/src/modules/common/helpers.js
@@ -26,3 +26,11 @@ export const isRetina = () =>
     window.matchMedia(
       '(-webkit-min-device-pixel-ratio: 1.5),(-moz-min-device-pixel-ratio: 1.5),(min-device-pixel-ratio: 1.5)'
     ).matches);
+
+export function replaceLanguageInPath(pathname: string, language: string) {
+  const nextPathname = pathname.split('/');
+  // Replace language that's at the root index in the path
+  nextPathname.splice(1, 1, language);
+
+  return nextPathname.join('/');
+}

--- a/src/modules/common/helpers.js
+++ b/src/modules/common/helpers.js
@@ -26,11 +26,3 @@ export const isRetina = () =>
     window.matchMedia(
       '(-webkit-min-device-pixel-ratio: 1.5),(-moz-min-device-pixel-ratio: 1.5),(min-device-pixel-ratio: 1.5)'
     ).matches);
-
-export function replaceLanguageInPath(pathname: string, language: string) {
-  const nextPathname = pathname.split('/');
-  // Replace language that's at the root index in the path
-  nextPathname.splice(1, 1, language);
-
-  return nextPathname.join('/');
-}

--- a/src/modules/common/history.js
+++ b/src/modules/common/history.js
@@ -1,0 +1,7 @@
+// @flow
+
+import { createBrowserHistory } from 'history';
+
+const history = createBrowserHistory();
+
+export default history;

--- a/src/modules/common/hooks/useReactRouterNavigationSideEffect.js
+++ b/src/modules/common/hooks/useReactRouterNavigationSideEffect.js
@@ -1,0 +1,25 @@
+// @flow
+
+// $FlowIgnore
+import { useEffect } from 'react';
+// $FlowIgnore
+import { useHistory, useLocation } from 'react-router';
+
+/**
+ * Call callback when navigating with react-router's <Link />
+ *
+ * Implementation inspired by
+ * https://reacttraining.com/react-router/web/guides/scroll-restoration
+ */
+const useReactRouterNavigationSideEffect = (callback: () => void) => {
+  const { pathname } = useLocation();
+  const { action } = useHistory();
+
+  useEffect(() => {
+    if (action === 'PUSH') {
+      callback();
+    }
+  }, [action, pathname, callback]);
+};
+
+export default useReactRouterNavigationSideEffect;

--- a/src/modules/common/hooks/useScrollToTop.js
+++ b/src/modules/common/hooks/useScrollToTop.js
@@ -1,0 +1,15 @@
+// @flow
+
+import useReactRouterNavigationSideEffect from './useReactRouterNavigationSideEffect';
+
+/**
+ * Ensure that browser scrolls to top when navigating using
+ * <Link> from react-router-dom.
+ */
+const useScrollToTop = () => {
+  useReactRouterNavigationSideEffect(() => {
+    window.scrollTo(0, 0);
+  });
+};
+
+export default useScrollToTop;

--- a/src/modules/common/i18n.js
+++ b/src/modules/common/i18n.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 
 import { SUPPORTED_LANGUAGES } from '../language/constants';
 import { DEFAULT_LANG } from './constants';
-import { replaceLanguageInPath } from './helpers';
+import { replaceLanguageInPath } from './pathUtils';
 import history from './history';
 
 const getTranslations = () => ({

--- a/src/modules/common/i18n.js
+++ b/src/modules/common/i18n.js
@@ -5,6 +5,8 @@ import moment from 'moment';
 
 import { SUPPORTED_LANGUAGES } from '../language/constants';
 import { DEFAULT_LANG } from './constants';
+import { replaceLanguageInPath } from './helpers';
+import history from './history';
 
 const getTranslations = () => ({
   fi: {
@@ -46,6 +48,10 @@ i18n
       interpolation: {
         escapeValue: false,
       },
+      detection: {
+        order: ['path', 'localStorage'],
+        checkWhitelist: true,
+      },
     },
     (err, t) => {
       if (err) {
@@ -54,6 +60,24 @@ i18n
       }
     }
   );
+
+// replace language in url so that the pathname will reflect the current
+// language when language is changed by using i18n.changeLanguage
+// Replace language only when it is changed, not on initialization.
+i18n.on('languageChanged', (nextLanguage) => {
+  // If necessary, change language in pathname
+  const { pathname } = window.location;
+  const containsLanguage = supportedLanguages.reduce(
+    (contains, language) => contains || pathname.includes(`/${language}/`),
+    false
+  );
+
+  if (containsLanguage) {
+    const nextPathname = replaceLanguageInPath(pathname, nextLanguage);
+
+    history.replace(nextPathname);
+  }
+});
 
 // Auto-detected language generally has a country code. Ignore it.
 export const getCurrentLanguage = () => i18n.language.split('-')[0];

--- a/src/modules/common/i18n.js
+++ b/src/modules/common/i18n.js
@@ -66,7 +66,7 @@ i18n
 // Replace language only when it is changed, not on initialization.
 i18n.on('languageChanged', (nextLanguage) => {
   // If necessary, change language in pathname
-  const { pathname } = window.location;
+  const { pathname, ...rest } = window.location;
   const containsLanguage = supportedLanguages.reduce(
     (contains, language) => contains || pathname.includes(`/${language}/`),
     false
@@ -75,7 +75,7 @@ i18n.on('languageChanged', (nextLanguage) => {
   if (containsLanguage) {
     const nextPathname = replaceLanguageInPath(pathname, nextLanguage);
 
-    history.replace(nextPathname);
+    history.replace({ pathname: nextPathname, ...rest });
   }
 });
 

--- a/src/modules/common/pathUtils.js
+++ b/src/modules/common/pathUtils.js
@@ -1,0 +1,54 @@
+// @flow
+
+import type { BrowserLocation } from 'history';
+
+function shouldAddSlash(pathname?: string): boolean {
+  if (!pathname) {
+    return false;
+  }
+
+  return pathname.slice(0, 1) !== '/';
+}
+
+function buildPathname(...parts: string[]) {
+  return parts.reduce((acc, part) => {
+    const addSlash = shouldAddSlash(part);
+
+    return `${acc}${addSlash ? '/' : ''}${part}`;
+  }, '');
+}
+
+export function getPathnameWithLanguage(path: string, lang: string): string {
+  return buildPathname(lang, path);
+}
+
+export function getLocationWithLanguage(
+  location: $Shape<BrowserLocation>,
+  lang: string
+): $Shape<BrowserLocation> {
+  const { pathname } = location;
+
+  return {
+    ...location,
+    pathname: pathname ? buildPathname(lang, pathname) : pathname,
+  };
+}
+
+export function getLocationFactoryWithLanguage(
+  locationFactory: (location: BrowserLocation) => $Shape<BrowserLocation>,
+  lang: string
+) {
+  return ({ pathname, ...rest }: BrowserLocation): $Shape<BrowserLocation> =>
+    locationFactory({
+      ...rest,
+      pathname: buildPathname(lang, pathname),
+    });
+}
+
+export function replaceLanguageInPath(pathname: string, language: string) {
+  const nextPathname = pathname.split('/');
+  // Replace language that's at the root index in the path
+  nextPathname.splice(1, 1, language);
+
+  return nextPathname.join('/');
+}

--- a/src/modules/common/routes.js
+++ b/src/modules/common/routes.js
@@ -1,0 +1,9 @@
+// @flow
+
+import { languageParam } from '../language/constants';
+
+const routerPaths = {
+  singleUnit: `/${languageParam}/unit/:unitId`,
+};
+
+export default routerPaths;

--- a/src/modules/home/components/HomeContainer.js
+++ b/src/modules/home/components/HomeContainer.js
@@ -11,7 +11,7 @@ import { getUnitPosition, getAttr } from '../../unit/helpers';
 import { getUnitById } from '../../unit/selectors';
 import UnitDetails from '../../unit/components/UnitDetailsContainer';
 import UnitBrowserContainer from '../../unit/components/UnitBrowserContainer';
-import { routerPaths } from '../../common/constants';
+import routerPaths from '../../common/routes';
 import useIsMobile from '../../common/hooks/useIsMobile';
 import Page from '../../common/components/Page';
 import Map from '../../map/components/Map';

--- a/src/modules/home/components/Logo.js
+++ b/src/modules/home/components/Logo.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+
+import Link from '../../common/components/Link';
 
 const Logo = () => {
   const { t } = useTranslation();

--- a/src/modules/language/constants.js
+++ b/src/modules/language/constants.js
@@ -14,3 +14,7 @@ export const languageActions = {
 export const MODULE_NAME = 'language';
 
 export type LanguageState = string;
+
+export const languageParam = `:language(${Object.values(
+  SUPPORTED_LANGUAGES
+).join('|')})`;

--- a/src/modules/map/components/Map.js
+++ b/src/modules/map/components/Map.js
@@ -50,7 +50,7 @@ const Map = forwardRef(({ selectedUnitId, onCenterMapToUnit }: Props, ref) => {
   const openUnit = useCallback(
     (unitId: string) => {
       history.push({
-        pathname: `/unit/${unitId}`,
+        pathname: `/${language}/unit/${unitId}`,
         search,
       });
     },

--- a/src/modules/map/components/Map.js
+++ b/src/modules/map/components/Map.js
@@ -49,10 +49,9 @@ const Map = forwardRef(({ selectedUnitId, onCenterMapToUnit }: Props, ref) => {
 
   const openUnit = useCallback(
     (unitId: string) => {
-      history.push({
-        pathname: `/${language}/unit/${unitId}`,
-        search,
-      });
+      // Store current search so it can be re-applied if the user returns from
+      // the unit details view
+      history.push(`/${language}/unit/${unitId}`, { search });
     },
     [history, search]
   );

--- a/src/modules/search/components/UnitSuggestion.js
+++ b/src/modules/search/components/UnitSuggestion.js
@@ -1,9 +1,9 @@
 // @flow
 
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
+import Link from '../../common/components/Link';
 import ObservationStatus from '../../unit/components/ObservationStatus';
 import { getAttr } from '../../unit/helpers';
 import UnitIcon from '../../unit/components/UnitIcon';

--- a/src/modules/search/components/UnitSuggestion.js
+++ b/src/modules/search/components/UnitSuggestion.js
@@ -2,6 +2,8 @@
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+// $FlowIgnore
+import { useLocation } from 'react-router';
 
 import Link from '../../common/components/Link';
 import ObservationStatus from '../../unit/components/ObservationStatus';
@@ -18,10 +20,11 @@ const UnitSuggestion = ({ unit, ...rest }: Props) => {
       languages: [language],
     },
   } = useTranslation();
+  const { search } = useLocation();
 
   return (
     <Link
-      to={`/unit/${unit.id}`}
+      to={{ pathname: `/unit/${unit.id}`, state: { search } }}
       className="search-suggestions__result"
       {...rest}
     >

--- a/src/modules/unit/components/LanguageChanger.js
+++ b/src/modules/unit/components/LanguageChanger.js
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 // $FlowIgnore
 import { useLocation, Link } from 'react-router-dom';
 
-import { replaceLanguageInPath } from '../../common/helpers';
+import { replaceLanguageInPath } from '../../common/pathUtils';
 import { SUPPORTED_LANGUAGES } from '../../language/constants';
 
 type Props = {

--- a/src/modules/unit/components/LanguageChanger.js
+++ b/src/modules/unit/components/LanguageChanger.js
@@ -1,7 +1,10 @@
 // @flow
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+// $FlowIgnore
+import { useLocation, Link } from 'react-router-dom';
 
+import { replaceLanguageInPath } from '../../common/helpers';
 import { SUPPORTED_LANGUAGES } from '../../language/constants';
 
 type Props = {
@@ -10,11 +13,11 @@ type Props = {
 
 const LanguageChanger = ({ isMobile = false }: Props) => {
   const {
-    i18n,
     i18n: {
       languages: [activeLanguage],
     },
   } = useTranslation();
+  const { pathname } = useLocation();
 
   return (
     <div className={isMobile ? 'language-changer__mobile' : 'language-changer'}>
@@ -25,17 +28,13 @@ const LanguageChanger = ({ isMobile = false }: Props) => {
         .map(([languageKey, languageValue], index) => (
           <div key={languageKey} style={{ display: 'flex' }}>
             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-            <a
-              onClick={(e) => {
-                e.preventDefault();
-                i18n.changeLanguage(SUPPORTED_LANGUAGES[languageKey]);
-              }}
+            <Link
               lang={languageValue}
-              // Empty href makes the anchor focusable
-              href=""
+              // $FlowIgnore
+              to={replaceLanguageInPath(pathname, languageValue)}
             >
               {languageKey}
-            </a>
+            </Link>
             {index < Object.keys(SUPPORTED_LANGUAGES).length - 2 &&
             !isMobile ? (
               <div style={{ marginLeft: 2, marginRight: 2 }}>|</div>

--- a/src/modules/unit/components/ListView.js
+++ b/src/modules/unit/components/ListView.js
@@ -3,6 +3,7 @@
 // eslint-disable-next-line max-classes-per-file
 import React, { Component } from 'react';
 import { withTranslation } from 'react-i18next';
+import { withRouter } from 'react-router-dom';
 import isEqual from 'lodash/isEqual';
 import values from 'lodash/values';
 
@@ -19,6 +20,7 @@ import UnitIcon from './UnitIcon';
 type UnitListItemProps = {
   unit: Object,
   activeLanguage: string,
+  locationSearch: string,
 };
 
 class UnitListItem extends Component<UnitListItemProps> {
@@ -29,10 +31,13 @@ class UnitListItem extends Component<UnitListItemProps> {
   }
 
   render() {
-    const { unit, activeLanguage } = this.props;
+    const { unit, activeLanguage, locationSearch } = this.props;
 
     return (
-      <Link to={`/unit/${unit.id}`} className="list-view-item">
+      <Link
+        to={{ pathname: `/unit/${unit.id}`, state: { search: locationSearch } }}
+        className="list-view-item"
+      >
         <div className="list-view-item__unit-marker">
           <UnitIcon unit={unit} />
         </div>
@@ -62,6 +67,9 @@ type Props = {
   },
   position: [number, number],
   leafletMap: Object,
+  location: {
+    search: string,
+  },
 };
 
 type State = {
@@ -146,7 +154,7 @@ export class ListViewBase extends Component<Props, State> {
   }
 
   render() {
-    const { services, isLoading, t, i18n, units } = this.props;
+    const { services, isLoading, t, i18n, units, location } = this.props;
     const { sortKey, maxUnitCount } = this.state;
     const totalUnits = units.length;
     const renderedUnits = isLoading
@@ -172,6 +180,7 @@ export class ListViewBase extends Component<Props, State> {
                   services={services}
                   key={unit.id}
                   activeLanguage={i18n.languages[0]}
+                  locationSearch={location.search}
                 />
               ))}
             {renderedUnits.length !== totalUnits && (
@@ -196,4 +205,4 @@ export class ListViewBase extends Component<Props, State> {
   }
 }
 
-export default withTranslation()(ListViewBase);
+export default withRouter(withTranslation()(ListViewBase));

--- a/src/modules/unit/components/ListView.js
+++ b/src/modules/unit/components/ListView.js
@@ -3,10 +3,10 @@
 // eslint-disable-next-line max-classes-per-file
 import React, { Component } from 'react';
 import { withTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
 import isEqual from 'lodash/isEqual';
 import values from 'lodash/values';
 
+import Link from '../../common/components/Link';
 import SMIcon from '../../home/components/SMIcon';
 import Loading from '../../home/components/Loading';
 import * as unitHelpers from '../helpers';

--- a/src/modules/unit/components/SingleUnitContainer.js
+++ b/src/modules/unit/components/SingleUnitContainer.js
@@ -5,12 +5,12 @@ import type { Node } from 'react';
 import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
 import breaks from 'remark-breaks';
 import upperFirst from 'lodash/upperFirst';
 import get from 'lodash/get';
 import has from 'lodash/has';
 
+import Link from '../../common/components/Link';
 import SMIcon from '../../home/components/SMIcon';
 import {
   getAttr,

--- a/src/modules/unit/components/SingleUnitContainer.js
+++ b/src/modules/unit/components/SingleUnitContainer.js
@@ -9,6 +9,8 @@ import breaks from 'remark-breaks';
 import upperFirst from 'lodash/upperFirst';
 import get from 'lodash/get';
 import has from 'lodash/has';
+// $FlowIgnore
+import { useLocation } from 'react-router';
 
 import Link from '../../common/components/Link';
 import SMIcon from '../../home/components/SMIcon';
@@ -51,6 +53,7 @@ export const Header = ({ unit, services, isLoading }: HeaderProps) => {
       languages: [language],
     },
   } = useTranslation();
+  const location = useLocation();
 
   const unitAddress = unit ? getAttr(unit.street_address, language) : null;
   const unitZIP = unit ? unit.address_zip : null;
@@ -72,7 +75,8 @@ export const Header = ({ unit, services, isLoading }: HeaderProps) => {
         </div>
         <div style={{ alignSelf: 'center' }}>
           <Link
-            to="/"
+            // If there was a search saved into location state, re-apply it
+            to={`/${location.state ? location.state.search : ''}`}
             className="unit-container-close-button close-unit-container"
           >
             <SMIcon icon="close" aria-label={t('UNIT_CONTAINER.CLOSE')} />

--- a/src/modules/unit/components/UnitBrowser.js
+++ b/src/modules/unit/components/UnitBrowser.js
@@ -161,7 +161,7 @@ class UnitBrowser extends Component<Props, State> {
     const searchParams = new URLSearchParams(search);
     searchParams.set(key, value);
 
-    history.push({
+    history.replace({
       search: searchParams.toString(),
     });
   };

--- a/src/modules/unit/components/__tests__/LanguageChanger.test.js
+++ b/src/modules/unit/components/__tests__/LanguageChanger.test.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 
-import i18n from '../../../common/i18n';
 import { mount } from '../../../common/enzymeHelpers';
 import LanguageChanger from '../LanguageChanger';
 
@@ -16,18 +15,5 @@ describe('<LanguageChanger />', () => {
     wrapper.find('a').forEach((element) => {
       expect(element.prop('lang')).toBeDefined();
     });
-  });
-
-  it('should change language when an option is clicked', () => {
-    const preventDefault = jest.fn();
-    const mockEvent = { preventDefault };
-    const wrapper = getWrapper();
-    const element = wrapper.find('a').at(0);
-    const changeLanguageSpy = jest.spyOn(i18n, 'changeLanguage');
-
-    element.simulate('click', mockEvent);
-
-    expect(preventDefault).toHaveBeenCalledTimes(1);
-    expect(changeLanguageSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/modules/unit/components/__tests__/SingeluUnitContainer.test.js
+++ b/src/modules/unit/components/__tests__/SingeluUnitContainer.test.js
@@ -182,7 +182,7 @@ describe('<SingleUnitContainer />', () => {
       // It should exist
       expect(closeButton.length > 0).toBeTruthy();
       // It should take the user to the root route
-      expect(closeButton.prop('href')).toEqual('/');
+      expect(closeButton.prop('href')).toEqual('/fi/');
     });
   });
 

--- a/src/modules/unit/components/_unit-popup.scss
+++ b/src/modules/unit/components/_unit-popup.scss
@@ -18,7 +18,7 @@
       background: $status-unknown;
       color: $ui-text;
       text-transform: uppercase;
-      font-size: 0.8em;
+      font-size: 10px;
 
       &--good {
         background: $status-ok;
@@ -38,6 +38,7 @@
       margin: 0;
       font-family: 'Lato', sans-serif;
       font-weight: 700;
+      font-size: 12px;
     }
   }
 }


### PR DESCRIPTION
## Description

By including the language in the URL, we make it possible for the site to be indexed in multiple languages.

This PR uses an approach where the user is redirected from non-language-aware addresses to a language aware version. In order to avoid re-directs, the Link component automatically applies the current language to paths.

I also fixed some navigation related bugs in this PR:
* Search parameters were not retained when an unit was opened
* Focus did not reset on page change
* Scroll was not reset on page change

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-134](https://helsinkisolutionoffice.atlassian.net/browse/ULK-134)
