### PR TITLE
ULK-133 | Add unit name in the slug of the unit details url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 -   Robots.txt file
 -   Language in url
+-   Unit names as slugs to unit urls
 
 ### Changed
 

--- a/src/domain/app/appRoutes.ts
+++ b/src/domain/app/appRoutes.ts
@@ -1,7 +1,7 @@
 import { languageParam } from "../i18n/i18nConstants";
 
 const routerPaths = {
-  unitDetails: `/${languageParam}/unit/:unitId`,
+  unitDetails: `/${languageParam}/unit/:unitId([^-]+):delimiter([$-])?:unitName?`,
   unitBrowser: `/${languageParam}`,
   unitBrowserSearch: `/${languageParam}/search`,
 };

--- a/src/domain/app/appRoutes.ts
+++ b/src/domain/app/appRoutes.ts
@@ -6,4 +6,9 @@ const routerPaths = {
   unitBrowserSearch: `/${languageParam}/search`,
 };
 
+export type UnitDetailsParams = {
+  unitId: string;
+  unitName?: string;
+};
+
 export default routerPaths;

--- a/src/domain/home/HomeContainer.tsx
+++ b/src/domain/home/HomeContainer.tsx
@@ -114,16 +114,8 @@ function HomeContainer() {
           <Route
             exact
             path={routerPaths.unitDetails}
-            render={({
-              match: {
-                params: { unitId },
-              },
-            }) => (
-              <UnitDetails
-                // @ts-ignore
-                unitId={unitId}
-                onCenterMapToUnit={handleCenterMapToUnit}
-              />
+            render={() => (
+              <UnitDetails onCenterMapToUnit={handleCenterMapToUnit} />
             )}
           />
           <Route

--- a/src/domain/map/Map.tsx
+++ b/src/domain/map/Map.tsx
@@ -54,7 +54,7 @@ function Map({ onCenterMapToUnit, mapRef, leafletElementRef }: Props) {
   );
 
   const openUnit = useCallback(
-    (unitId: string) => {
+    (unitId: string, unitName: string) => {
       let state: AppSearchLocationState = {
         previous: `${PathUtils.removeLanguageFromPathname(pathname)}${search}`,
         search: appSearch,
@@ -70,7 +70,10 @@ function Map({ onCenterMapToUnit, mapRef, leafletElementRef }: Props) {
       }
       // Store current search state so it can be re-applied if the user returns
       // from the unit details view
-      history.push(`/${language}/unit/${unitId}`, state);
+      history.push(
+        `/${language}/unit/${unitId}-${encodeURIComponent(unitName)}`,
+        state
+      );
     },
     [
       history,

--- a/src/domain/map/Map.tsx
+++ b/src/domain/map/Map.tsx
@@ -54,11 +54,12 @@ function Map({ onCenterMapToUnit, mapRef, leafletElementRef }: Props) {
   );
 
   const openUnit = useCallback(
-    (unitId: string, unitName: string) => {
+    (unitId: string, unitName?: string) => {
       let state: AppSearchLocationState = {
         previous: `${PathUtils.removeLanguageFromPathname(pathname)}${search}`,
         search: appSearch,
       };
+      let nextPathname = `/${language}/unit/${unitId}`;
 
       // If the user opens an unit while an unit is already open, inherit the
       // location state from search
@@ -68,12 +69,16 @@ function Map({ onCenterMapToUnit, mapRef, leafletElementRef }: Props) {
           search: locationState?.search,
         };
       }
+      // If the unit has a name in the current language, use it in the url
+      if (unitName) {
+        nextPathname = `/${language}/unit/${unitId}-${encodeURIComponent(
+          unitName
+        )}`;
+      }
+
       // Store current search state so it can be re-applied if the user returns
       // from the unit details view
-      history.push(
-        `/${language}/unit/${unitId}-${encodeURIComponent(unitName)}`,
-        state
-      );
+      history.push(nextPathname, state);
     },
     [
       history,

--- a/src/domain/map/MapUnit.tsx
+++ b/src/domain/map/MapUnit.tsx
@@ -1,16 +1,17 @@
 import L from "leaflet";
 import { Component } from "react";
+import { WithTranslationProps, withTranslation } from "react-i18next";
 
 import { Unit } from "../unit/unitConstants";
-import { getUnitQuality } from "../unit/unitHelpers";
+import { getAttr, getUnitQuality } from "../unit/unitHelpers";
 import UnitGeometry from "./MapGeometry";
 import UnitMarker from "./MapUnitMarker";
 
-type Props = {
+type Props = WithTranslationProps & {
   unit: Unit;
   isSelected: boolean;
   zoomLevel: number;
-  openUnit: (unitId: string) => void;
+  openUnit: (unitId: string, unitName: string) => void;
 };
 
 class MapUnit extends Component<Props> {
@@ -32,10 +33,10 @@ class MapUnit extends Component<Props> {
   }
 
   handleClick(e: L.LeafletMouseEvent) {
-    const { unit, openUnit } = this.props;
+    const { unit, openUnit, i18n } = this.props;
 
     L.DomEvent.stopPropagation(e);
-    openUnit(unit.id);
+    openUnit(unit.id, getAttr(unit.name, i18n?.languages[0]));
   }
 
   render() {
@@ -66,4 +67,4 @@ class MapUnit extends Component<Props> {
   }
 }
 
-export default MapUnit;
+export default withTranslation()(MapUnit);

--- a/src/domain/map/MapUnit.tsx
+++ b/src/domain/map/MapUnit.tsx
@@ -3,7 +3,7 @@ import { Component } from "react";
 import { WithTranslationProps, withTranslation } from "react-i18next";
 
 import { Unit } from "../unit/unitConstants";
-import { getAttr, getUnitQuality } from "../unit/unitHelpers";
+import { getUnitQuality } from "../unit/unitHelpers";
 import UnitGeometry from "./MapGeometry";
 import UnitMarker from "./MapUnitMarker";
 
@@ -11,7 +11,7 @@ type Props = WithTranslationProps & {
   unit: Unit;
   isSelected: boolean;
   zoomLevel: number;
-  openUnit: (unitId: string, unitName: string) => void;
+  openUnit: (unitId: string, unitName?: string) => void;
 };
 
 class MapUnit extends Component<Props> {
@@ -36,7 +36,8 @@ class MapUnit extends Component<Props> {
     const { unit, openUnit, i18n } = this.props;
 
     L.DomEvent.stopPropagation(e);
-    openUnit(unit.id, getAttr(unit.name, i18n?.languages[0]));
+    // @ts-ignore
+    openUnit(unit.id, unit.name[i18n?.languages[0]]);
   }
 
   render() {

--- a/src/domain/map/MapUnits.tsx
+++ b/src/domain/map/MapUnits.tsx
@@ -7,7 +7,7 @@ import MapUnit from "./MapUnit";
 type Props = {
   units: Unit[];
   selectedUnit: Unit;
-  openUnit: (unitId: string, unitName: string) => void;
+  openUnit: (unitId: string, unitName?: string) => void;
   zoomLevel: number;
 };
 

--- a/src/domain/map/MapUnits.tsx
+++ b/src/domain/map/MapUnits.tsx
@@ -7,7 +7,7 @@ import MapUnit from "./MapUnit";
 type Props = {
   units: Unit[];
   selectedUnit: Unit;
-  openUnit: (unitId: string) => void;
+  openUnit: (unitId: string, unitName: string) => void;
   zoomLevel: number;
 };
 

--- a/src/domain/map/MapView.tsx
+++ b/src/domain/map/MapView.tsx
@@ -24,7 +24,7 @@ type Props = {
   selectedUnit: Unit;
   onCenterMapToUnit: (unit: Unit) => void;
   activeLanguage: string;
-  openUnit: (unitId: string, unitName: string) => void;
+  openUnit: (unitId: string, unitName?: string) => void;
   t: (arg0: string) => string;
   setLocation: (coordinates: number[]) => void;
   position: [number, number];

--- a/src/domain/map/MapView.tsx
+++ b/src/domain/map/MapView.tsx
@@ -24,7 +24,7 @@ type Props = {
   selectedUnit: Unit;
   onCenterMapToUnit: (unit: Unit) => void;
   activeLanguage: string;
-  openUnit: (unitId: string) => void;
+  openUnit: (unitId: string, unitName: string) => void;
   t: (arg0: string) => string;
   setLocation: (coordinates: number[]) => void;
   position: [number, number];

--- a/src/domain/meta/LanguageMeta.tsx
+++ b/src/domain/meta/LanguageMeta.tsx
@@ -42,7 +42,6 @@ function LanguageMeta() {
         content={languageToLanguageAndLocale(language)}
       />
       <meta property="og:url" content={canonicalUrl} />
-      {/* $FlowIgnore */}
       {Object.values(SUPPORTED_LANGUAGES).map((supportedLanguage: string) => (
         <link
           key={supportedLanguage}

--- a/src/domain/meta/LanguageMeta.tsx
+++ b/src/domain/meta/LanguageMeta.tsx
@@ -37,11 +37,7 @@ function LanguageMeta() {
 
   return (
     <Helmet>
-      <meta
-        property="og:locale"
-        content={languageToLanguageAndLocale(language)}
-      />
-      <meta property="og:url" content={canonicalUrl} />
+      <link rel="canonical" href={canonicalUrl} />
       {Object.values(SUPPORTED_LANGUAGES).map((supportedLanguage: string) => (
         <link
           key={supportedLanguage}
@@ -55,6 +51,11 @@ function LanguageMeta() {
         hrefLang="x-default"
         href={PathUtils.removeLanguageFromUrl(canonicalUrl)}
       />
+      <meta
+        property="og:locale"
+        content={languageToLanguageAndLocale(language)}
+      />
+      <meta property="og:url" content={canonicalUrl} />
     </Helmet>
   );
 }

--- a/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
+++ b/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
@@ -32,7 +32,9 @@ const UnitListItem = React.memo<UnitListItemProps>(
     return (
       <Link
         to={{
-          pathname: `/unit/${unit.id}`,
+          pathname: `/unit/${unit.id}-${encodeURIComponent(
+            unitHelpers.getAttr(unit.name, language)
+          )}`,
           state: {
             previous: `${PathUtils.removeLanguageFromPathname(
               pathname

--- a/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
+++ b/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
@@ -29,12 +29,18 @@ const UnitListItem = React.memo<UnitListItemProps>(
     const { pathname, search } = useLocation();
     const appSearch = useAppSearch();
 
+    // @ts-ignore
+    const unitNameInLanguage = unit.name[language];
+    const unitPath = unitNameInLanguage
+      ? `/unit/${unit.id}-${encodeURIComponent(
+          unitHelpers.getAttr(unit.name, language)
+        )}`
+      : `/unit/${unit.id}`;
+
     return (
       <Link
         to={{
-          pathname: `/unit/${unit.id}-${encodeURIComponent(
-            unitHelpers.getAttr(unit.name, language)
-          )}`,
+          pathname: unitPath,
           state: {
             previous: `${PathUtils.removeLanguageFromPathname(
               pathname

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -33,6 +33,7 @@ import {
   getObservationTime,
   getOpeningHours,
 } from "../unitHelpers";
+import useSyncUnitNameWithLanguage from "./useSyncUnitNameWithLanguage";
 
 function shouldShowInfo(unit: Unit) {
   const hasExtensions =
@@ -55,8 +56,8 @@ type HeaderProps = {
 export function Header({ unit, services, isLoading }: HeaderProps) {
   const { t } = useTranslation();
   const language = useLanguage();
-
   const location = useLocation<{ previous?: string }>();
+
   const unitAddress = unit ? getAttr(unit.street_address, language) : null;
   const unitZIP = unit ? unit.address_zip : null;
   const unitMunicipality = unit ? unit.municipality : null;
@@ -386,6 +387,7 @@ function UnitDetails({ unitId, onCenterMapToUnit }: Props) {
       onCenterMapToUnit(unit);
     }
   }, [unit, onCenterMapToUnit]);
+  useSyncUnitNameWithLanguage(unit);
 
   const temperatureObservation = has(unit, "observations")
     ? getObservation(unit, "swimming_water_temperature")

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -5,7 +5,7 @@ import { ReactNode, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
 import { useSelector } from "react-redux";
-import { useLocation } from "react-router";
+import { useLocation, useParams } from "react-router";
 // @ts-ignore
 import breaks from "remark-breaks";
 
@@ -15,6 +15,7 @@ import Link from "../../../common/components/Link";
 import SMIcon from "../../../common/components/SMIcon";
 import useLanguage from "../../../common/hooks/useLanguage";
 import { AppState } from "../../app/appConstants";
+import { UnitDetailsParams } from "../../app/appRoutes";
 import { getIsLoading } from "../../app/appSelectors";
 import * as fromService from "../../service/selectors";
 import getServiceName from "../../service/serviceHelpers";
@@ -365,14 +366,13 @@ export function SingleUnitBody({
 }
 
 type Props = {
-  unitId: string;
   onCenterMapToUnit: (unit: Unit) => void;
 };
 
-function UnitDetails({ unitId, onCenterMapToUnit }: Props) {
+function UnitDetails({ onCenterMapToUnit }: Props) {
   const language = useLanguage();
   const { t } = useTranslation();
-
+  const { unitId } = useParams<UnitDetailsParams>();
   const services = useSelector(fromService.getServicesObject);
   const unit = useSelector<AppState, Unit>((state) =>
     fromUnit.getUnitById(state, {

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -1,4 +1,5 @@
 import moment from "moment";
+import ReactRouter from "react-router";
 
 import { mount } from "../../../enzymeHelpers";
 import UnitDetails from "../UnitDetails";
@@ -160,12 +161,15 @@ const unit = {
 };
 
 const defaultProps = {
-  unitId: "40142",
   onCenterMapToUnit: () => {},
 };
 
-const getWrapper = (props, modifiedUnit) =>
-  mount(<UnitDetails {...defaultProps} {...props} />, {
+const getWrapper = (props, modifiedUnit) => {
+  jest.spyOn(ReactRouter, "useParams").mockReturnValue({
+    unitId: "40142",
+  });
+
+  return mount(<UnitDetails {...defaultProps} {...props} />, {
     preloadedState: {
       unit: {
         byId: {
@@ -184,6 +188,7 @@ const getWrapper = (props, modifiedUnit) =>
       },
     },
   });
+};
 
 describe("<UnitDetails />", () => {
   describe("header", () => {

--- a/src/domain/unit/details/useSyncUnitNameWithLanguage.ts
+++ b/src/domain/unit/details/useSyncUnitNameWithLanguage.ts
@@ -2,12 +2,9 @@ import { useEffect } from "react";
 import { useHistory, useParams } from "react-router";
 
 import useLanguage from "../../../common/hooks/useLanguage";
+import { UnitDetailsParams } from "../../app/appRoutes";
 import { Unit } from "../unitConstants";
 import { getAttr } from "../unitHelpers";
-
-type UnitDetailsParams = {
-  unitName?: string;
-};
 
 // If a user receives a link without the language parameter, but with the slug,
 // the slug can end up being in the wrong language.

--- a/src/domain/unit/details/useSyncUnitNameWithLanguage.ts
+++ b/src/domain/unit/details/useSyncUnitNameWithLanguage.ts
@@ -1,10 +1,8 @@
 import { useEffect } from "react";
-import { useHistory, useParams } from "react-router";
+import { useHistory, useLocation } from "react-router";
 
 import useLanguage from "../../../common/hooks/useLanguage";
-import { UnitDetailsParams } from "../../app/appRoutes";
 import { Unit } from "../unitConstants";
-import { getAttr } from "../unitHelpers";
 
 // If a user receives a link without the language parameter, but with the slug,
 // the slug can end up being in the wrong language.
@@ -14,23 +12,29 @@ import { getAttr } from "../unitHelpers";
 // To combat the two above niche cases this hook will attempt to keep the slug
 // in sync with the application language.
 function useSyncUnitNameWithLanguage(unit?: Unit) {
-  const { unitName } = useParams<UnitDetailsParams>();
   const language = useLanguage();
   const history = useHistory();
+  const { pathname } = useLocation();
 
   useEffect(() => {
     if (unit) {
-      const unitNameInLanguage = getAttr(unit.name, language);
+      let nextPathname = `/${language}/unit/${unit.id}`;
+      // @ts-ignore
+      const unitNameInLanguage = unit.name[language];
 
-      if (unitName && decodeURIComponent(unitName) !== unitNameInLanguage) {
-        history.replace(
-          `/${language}/unit/${unit.id}-${encodeURIComponent(
-            unitNameInLanguage
-          )}`
-        );
+      // If the unit has a name in the current language, add it into the slug
+      if (unitNameInLanguage) {
+        nextPathname = `${nextPathname}-${encodeURIComponent(
+          unitNameInLanguage
+        )}`;
+      }
+
+      // If the pathname we want is not applied, apply it
+      if (nextPathname !== pathname) {
+        history.replace(nextPathname);
       }
     }
-  }, [history, language, unit, unitName]);
+  }, [history, language, unit, pathname]);
 }
 
 export default useSyncUnitNameWithLanguage;

--- a/src/domain/unit/details/useSyncUnitNameWithLanguage.ts
+++ b/src/domain/unit/details/useSyncUnitNameWithLanguage.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { useHistory, useParams } from "react-router";
+
+import useLanguage from "../../../common/hooks/useLanguage";
+import { Unit } from "../unitConstants";
+import { getAttr } from "../unitHelpers";
+
+type UnitDetailsParams = {
+  unitName?: string;
+};
+
+// If a user receives a link without the language parameter, but with the slug,
+// the slug can end up being in the wrong language.
+//
+// If the user switches languages, the slug will be kept as it.
+//
+// To combat the two above niche cases this hook will attempt to keep the slug
+// in sync with the application language.
+function useSyncUnitNameWithLanguage(unit?: Unit) {
+  const { unitName } = useParams<UnitDetailsParams>();
+  const language = useLanguage();
+  const history = useHistory();
+
+  useEffect(() => {
+    if (unit) {
+      const unitNameInLanguage = getAttr(unit.name, language);
+
+      if (unitName && decodeURIComponent(unitName) !== unitNameInLanguage) {
+        history.replace(
+          `/${language}/unit/${unit.id}-${encodeURIComponent(
+            unitNameInLanguage
+          )}`
+        );
+      }
+    }
+  }, [history, language, unit, unitName]);
+}
+
+export default useSyncUnitNameWithLanguage;


### PR DESCRIPTION
## Description

After this change, unit details pages will attempt to add the unit's name into the slug of the url.

* If the unit's name is not translated to the current language, the slug won't be amended
    * The main purpose is to make the link more readable for users--insensible content in the slug may hamper this cognition
* The slug is updated when language is updated
* By default links point to slugs that have a unit name in them
* Meta tags have been amended to take the changed slug into account

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-133](https://helsinkisolutionoffice.atlassian.net/browse/ULK-133)
