### PR TITLE
ULK-141 | Fix basemap always using Finnish terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 -   [Accessibility] Capturing focus to the middle of the page when opening the details of an unit
+-   Base map not respecting application language
 
 ## [1.1.6] - 2021-02-16
 

--- a/src/domain/map/MapView.tsx
+++ b/src/domain/map/MapView.tsx
@@ -1,5 +1,6 @@
+import get from "lodash/get";
 import { Component, RefObject } from "react";
-import { withTranslation } from "react-i18next";
+import { withTranslation, WithTranslation } from "react-i18next";
 import { Map, TileLayer, ZoomControl } from "react-leaflet";
 
 import OSMIcon from "../../common/components/OSMIcon";
@@ -20,12 +21,11 @@ import {
 } from "./mapConstants";
 import latLngToArray from "./mapHelpers";
 
-type Props = {
+type Props = WithTranslation & {
   selectedUnit: Unit;
   onCenterMapToUnit: (unit: Unit) => void;
   activeLanguage: string;
   openUnit: (unitId: string, unitName?: string) => void;
-  t: (arg0: string) => string;
   setLocation: (coordinates: number[]) => void;
   position: [number, number];
   units: Unit[];
@@ -93,7 +93,17 @@ class MapView extends Component<Props, State> {
   };
 
   render() {
-    const { position, selectedUnit, units, openUnit, mapRef, t } = this.props;
+    const {
+      position,
+      selectedUnit,
+      units,
+      openUnit,
+      mapRef,
+      t,
+      i18n: {
+        languages: [language],
+      },
+    } = this.props;
 
     const { zoomLevel } = this.state;
 
@@ -120,7 +130,11 @@ class MapView extends Component<Props, State> {
           onzoomend={this.handleZoom}
         >
           <TileLayer
-            url={isRetina() ? MAP_RETINA_URL : MAP_URL}
+            url={
+              isRetina()
+                ? get(MAP_RETINA_URL, language)
+                : get(MAP_URL, language)
+            }
             attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           />
           <MapUserLocationMarker />

--- a/src/domain/map/mapConstants.ts
+++ b/src/domain/map/mapConstants.ts
@@ -4,10 +4,17 @@ import { Map } from "react-leaflet";
 
 import { normalizeActionName } from "../utils";
 
-export const MAP_URL =
-  "https://tiles.hel.ninja/styles/hel-osm-light/{z}/{x}/{y}.png";
+export const MAP_URL = {
+  fi: "https://tiles.hel.ninja/styles/hel-osm-light/{z}/{x}/{y}.png",
+  sv: "https://tiles.hel.ninja/styles/hel-osm-light/{z}/{x}/{y}@sv.png",
+  en: "https://tiles.hel.ninja/styles/hel-osm-light/{z}/{x}/{y}@en.png",
+};
 
-export const MAP_RETINA_URL = MAP_URL.replace(".png", "@3x.png");
+export const MAP_RETINA_URL = {
+  fi: MAP_URL.fi.replace(".png", "@3x.png"),
+  sv: MAP_URL.sv.replace("@sv", "@3x@sv"),
+  en: MAP_URL.en.replace("@en", "@3x@en"),
+};
 
 export const DEFAULT_ZOOM = 12;
 


### PR DESCRIPTION
## Description

Previously the basemap was always in Finnish.

After this change the basemap that corresponds to the application language is used. The Finnish and English basemaps seem to be mostly the same, but the Swedish version has a very different copy.

## Context

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[ULK-141](https://helsinkisolutionoffice.atlassian.net/browse/ULK-141)

This change should fix this issue: https://github.com/City-of-Helsinki/outdoors-sports-map/issues/50
