### PR TITLE
Fix location store reset

### DIFF
--- a/src/domain/home/_home.scss
+++ b/src/domain/home/_home.scss
@@ -22,16 +22,20 @@
     }
 
     &.fill-color-background {
+      // When foreground is filled with background color, it should always fill
+      // the entire screen height, but not more, to enable proper behaviour with
+      // scrolling.
+      height: 100vh;
+
       border-bottom: solid #4d4d4d 4px;
       background-color: $ui-background;
-
       box-shadow: none;
     }
   }
 
   @media only screen and (min-width: $breakpoint) {
     width: 400px;
-    height: 100%;
+    height: 100vh;
 
     pointer-events: none;
 
@@ -43,6 +47,8 @@
   &-content {
     overflow-y: auto;
     pointer-events: none;
+    display: flex;
+    flex-direction: column;
 
     & > * {
       pointer-events: initial;

--- a/src/domain/map/Map.tsx
+++ b/src/domain/map/Map.tsx
@@ -72,7 +72,7 @@ function Map({ onCenterMapToUnit, mapRef, leafletElementRef }: Props) {
       // If the unit has a name in the current language, use it in the url
       if (unitName) {
         nextPathname = `/${language}/unit/${unitId}-${encodeURIComponent(
-          unitName
+          encodeURIComponent(unitName)
         )}`;
       }
 

--- a/src/domain/unit/UnitView.tsx
+++ b/src/domain/unit/UnitView.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { CSSProperties, ReactNode } from "react";
 
 type Props = {
   id: string;
@@ -6,6 +6,7 @@ type Props = {
   className: string;
   children: ReactNode;
   tabIndex?: number;
+  style?: CSSProperties;
 };
 
 export function View({

--- a/src/domain/unit/browser/UnitBrowser.tsx
+++ b/src/domain/unit/browser/UnitBrowser.tsx
@@ -1,5 +1,5 @@
 import values from "lodash/values";
-import { RefObject, useCallback, useState } from "react";
+import { RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Route } from "react-router-dom";
@@ -21,30 +21,6 @@ import UnitBrowserHeader from "./UnitBrowserHeader";
 import UnitBrowserFilters from "./filter/UnitBrowserFilter";
 import UnitBrowserResultList from "./resultList/UnitBrowserResultList";
 
-function calculateMaxHeight() {
-  const element = document.getElementById("always-visible");
-
-  if (element) {
-    const fixedPartHeight = element.offsetHeight;
-
-    // Plus header height
-    // This approach could likely be replaced with flexbox
-    return window.innerHeight - (fixedPartHeight + 64);
-  }
-
-  return window.innerHeight;
-}
-
-function useOnResize(callback: () => void) {
-  useCallback(() => {
-    window.addEventListener("resize", callback);
-
-    return () => {
-      window.removeEventListener("resize", callback);
-    };
-  }, [callback]);
-}
-
 type Props = {
   leafletMap?: RefObject<L.Map | null>;
   onViewChange: (coordinates: [number, number]) => void;
@@ -52,18 +28,11 @@ type Props = {
 
 function UnitBrowser({ onViewChange, leafletMap }: Props) {
   const { t } = useTranslation();
-  const [contentMaxHeight, setContentMaxHeight] = useState<number>();
   const doSearch = useDoSearch();
   const { sport, status } = useAppSearch();
   const isLoading = useSelector<AppState, boolean>(fromHome.getIsLoading);
   const address = useSelector<AppState, Address | undefined | null>(
     fromMap.getAddress
-  );
-
-  useOnResize(
-    useCallback(() => {
-      setContentMaxHeight(calculateMaxHeight());
-    }, [])
   );
 
   return (
@@ -72,7 +41,7 @@ function UnitBrowser({ onViewChange, leafletMap }: Props) {
       description={t("APP.DESCRIPTION")}
       className="unit-browser"
     >
-      <div id="always-visible" className="unit-browser__fixed">
+      <div className="unit-browser__fixed">
         <UnitBrowserHeader onViewChange={onViewChange} />
         {!isLoading && (
           <UnitBrowserFilters
@@ -99,16 +68,7 @@ function UnitBrowser({ onViewChange, leafletMap }: Props) {
       <Route
         path={routerPaths.unitBrowserSearch}
         render={() => {
-          return (
-            <div
-              className="unit-browser__content"
-              style={{
-                maxHeight: contentMaxHeight || calculateMaxHeight(),
-              }}
-            >
-              <UnitBrowserResultList leafletMap={leafletMap} />
-            </div>
-          );
+          return <UnitBrowserResultList leafletMap={leafletMap} />;
         }}
       />
       {t("UNIT_DETAILS.TMP_MESSAGE").length > 0 && (

--- a/src/domain/unit/browser/_unitBrowser.scss
+++ b/src/domain/unit/browser/_unitBrowser.scss
@@ -1,7 +1,9 @@
 .unit-browser {
   pointer-events: none;
   overflow: hidden;
-  height: 100%;
+  height: unset;
+  display: flex;
+  flex-direction: column;
 
   & > * {
     pointer-events: auto;

--- a/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
+++ b/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
@@ -33,7 +33,7 @@ const UnitListItem = React.memo<UnitListItemProps>(
     const unitNameInLanguage = unit.name[language];
     const unitPath = unitNameInLanguage
       ? `/unit/${unit.id}-${encodeURIComponent(
-          unitHelpers.getAttr(unit.name, language)
+          encodeURIComponent(unitHelpers.getAttr(unit.name, language))
         )}`
       : `/unit/${unit.id}`;
 

--- a/src/domain/unit/browser/resultList/_unitBrowserResultList.scss
+++ b/src/domain/unit/browser/resultList/_unitBrowserResultList.scss
@@ -1,4 +1,6 @@
 .list-view {
+  overflow: auto;
+
   .list-view__container {
     margin: 0;
 

--- a/src/domain/unit/details/useSyncUnitNameWithLanguage.ts
+++ b/src/domain/unit/details/useSyncUnitNameWithLanguage.ts
@@ -14,7 +14,7 @@ import { Unit } from "../unitConstants";
 function useSyncUnitNameWithLanguage(unit?: Unit) {
   const language = useLanguage();
   const history = useHistory();
-  const { pathname } = useLocation();
+  const { pathname, state } = useLocation();
 
   useEffect(() => {
     if (unit) {
@@ -29,12 +29,13 @@ function useSyncUnitNameWithLanguage(unit?: Unit) {
         )}`;
       }
 
-      // If the pathname we want is not applied, apply it
+      // If the pathname we want is not applied, apply it and don't lose current
+      // navigation state.
       if (nextPathname !== pathname) {
-        history.replace(nextPathname);
+        history.replace({ pathname: nextPathname, state });
       }
     }
-  }, [history, language, unit, pathname]);
+  }, [history, language, unit, pathname, state]);
 }
 
 export default useSyncUnitNameWithLanguage;


### PR DESCRIPTION
## Description

When the user completes a search, opens a unit and then closes the unit, they should be taken back to their original search.

Unexpected behaviour caused this stored search to be reset, which broke this functionality.

The `useSyncUnitNameWithLanguage` didn't properly pass on the current search state.

`useSyncUnitNameWithLanguage` was also unexpectedly fired, because the `history` package unexpectedly decoded paths before passing them on to the history API, causing "identical" urls to mismatch.

