### PR TITLE
Fix feedback form when user doesn't give email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+-   Feedback form always failing to send feedback
+
 ## [1.2.0] - 2021-06-22
 
 ### Added

--- a/src/domain/app/AppFeedbackModal.tsx
+++ b/src/domain/app/AppFeedbackModal.tsx
@@ -29,8 +29,8 @@ function AppFeedbackModal({ onClose, show }: Props) {
         feedback: { value: string };
         email: { value: string };
       };
-      const feedback = form?.feedback.value;
-      const email = form?.email.value;
+      const feedback = form?.feedback?.value;
+      const email = form?.email?.value;
 
       if (feedback) {
         dispatch(appActions.sendFeedback(feedback, email));


### PR DESCRIPTION
## Description

The feedback form would always fail if the user did not provide their email.

