### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.2.0] - 2021-06-23
+
 ### Fixed
 
--   Feedback form always failing to send feedback
+-   [#99](https://github.com/City-of-Helsinki/outdoors-sports-map/pull/99) Feedback form always failing to send feedback
 
 ## [1.2.0] - 2021-06-22
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outdoors-sports-map",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "start": "cross-env NODE_ENV=development react-scripts start",


### PR DESCRIPTION
## [1.2.0] - 2021-06-23

### Fixed

-   [#99](https://github.com/City-of-Helsinki/outdoors-sports-map/pull/99) Feedback form always failing to send feedback