### PR TITLE
HULK-4: Show heating information

### DIFF
--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -58,7 +58,8 @@
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Show results on map",
     "LIST_BUTTON": "Show results on map and on the list",
-    "CONTROL": "Control"
+    "CONTROL": "Control",
+    "HEATING": "Heating"
   },
   "UNIT_BROWSER": {
     "LOADING": "Loading the object",

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -57,7 +57,8 @@
     "PHONE": "Phone",
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Show results on map",
-    "LIST_BUTTON": "Show results on map and on the list"
+    "LIST_BUTTON": "Show results on map and on the list",
+    "CONTROL": "Control"
   },
   "UNIT_BROWSER": {
     "LOADING": "Loading the object",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -57,7 +57,8 @@
     "PHONE": "Puhelinnumero",
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Näytä tulokset kartalla",
-    "LIST_BUTTON": "Näytä tulokset kartalla ja listana"
+    "LIST_BUTTON": "Näytä tulokset kartalla ja listana",
+    "CONTROL": "Valvonta"
   },
   "UNIT_BROWSER": {
     "LOADING": "Ladataan kohdetta...",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -58,7 +58,8 @@
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Näytä tulokset kartalla",
     "LIST_BUTTON": "Näytä tulokset kartalla ja listana",
-    "CONTROL": "Valvonta"
+    "CONTROL": "Valvonta",
+    "HEATING": "Lämmitys"
   },
   "UNIT_BROWSER": {
     "LOADING": "Ladataan kohdetta...",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -58,7 +58,8 @@
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Visa resultat på karta",
     "LIST_BUTTON": "Visa resultat på karta och i listan",
-    "CONTROL": "Kontrollera"
+    "CONTROL": "Kontrollera",
+    "HEATING": "Uppvärmning"
   },
   "UNIT_BROWSER": {
     "LOADING": "Laddar objekt",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -57,7 +57,8 @@
     "PHONE": "Telefon",
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Visa resultat på karta",
-    "LIST_BUTTON": "Visa resultat på karta och i listan"
+    "LIST_BUTTON": "Visa resultat på karta och i listan",
+    "CONTROL": "Kontrollera"
   },
   "UNIT_BROWSER": {
     "LOADING": "Laddar objekt",

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -25,11 +25,12 @@ import UnitObservationStatus, {
   StatusUpdatedAgo,
 } from "../UnitObservationStatus";
 import * as fromUnit from "../state/selectors";
-import { Unit } from "../unitConstants";
+import { Unit, UnitConnectionTags } from "../unitConstants";
 import {
   createPalvelukarttaUrl,
   createReittiopasUrl,
   getAttr,
+  getConnectionByTag,
   getObservation,
   getObservationTime,
   getOpeningHours,
@@ -158,8 +159,10 @@ function LocationInfo({ unit }: LocationInfoProps) {
     unitExtraLipasSkiTrackFreestyle ||
     unitExtraLipasSkiTrackTraditional;
 
+  const unitControlConnection = getConnectionByTag(unit, UnitConnectionTags.CONTROL)
+
   // Should show info if at least some data is present
-  if (!(unit.phone || unit.url || hasExtras)) {
+  if (!(unit.phone || unit.url || hasExtras || unitControlConnection)) {
     return null;
   }
 
@@ -189,6 +192,12 @@ function LocationInfo({ unit }: LocationInfoProps) {
           ]
             .filter((item) => item)
             .join(", ")}
+        </p>
+      )}
+      {unitControlConnection !== undefined && (
+        <p className="no-margin">
+          {`${t("UNIT_DETAILS.CONTROL")}`}:{" "}
+          {getAttr(unitControlConnection.name, language)}
         </p>
       )}
       {unit.phone && (

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -159,10 +159,25 @@ function LocationInfo({ unit }: LocationInfoProps) {
     unitExtraLipasSkiTrackFreestyle ||
     unitExtraLipasSkiTrackTraditional;
 
-  const unitControlConnection = getConnectionByTag(unit, UnitConnectionTags.CONTROL)
+  const unitControlConnection = getConnectionByTag(
+    unit,
+    UnitConnectionTags.CONTROL
+  );
+  const unitHeatedConnection = getConnectionByTag(
+    unit,
+    UnitConnectionTags.HEATING
+  );
 
   // Should show info if at least some data is present
-  if (!(unit.phone || unit.url || hasExtras || unitControlConnection)) {
+  if (
+    !(
+      unit.phone ||
+      unit.url ||
+      hasExtras ||
+      unitControlConnection ||
+      unitHeatedConnection
+    )
+  ) {
     return null;
   }
 
@@ -198,6 +213,12 @@ function LocationInfo({ unit }: LocationInfoProps) {
         <p className="no-margin">
           {`${t("UNIT_DETAILS.CONTROL")}`}:{" "}
           {getAttr(unitControlConnection.name, language)}
+        </p>
+      )}
+      {unitHeatedConnection !== undefined && (
+        <p className="no-margin">
+          {`${t("UNIT_DETAILS.HEATING")}`}:{" "}
+          {getAttr(unitHeatedConnection.name, language)}
         </p>
       )}
       {unit.phone && (
@@ -251,7 +272,11 @@ type LocationRouteProps = {
   extraUrl?: string;
 };
 
-function LocationRoute({ routeUrl, palvelukarttaUrl, extraUrl }: LocationRouteProps) {
+function LocationRoute({
+  routeUrl,
+  palvelukarttaUrl,
+  extraUrl,
+}: LocationRouteProps) {
   const { t } = useTranslation();
 
   return (
@@ -381,11 +406,11 @@ export function SingleUnitBody({
 }: SingleUnitBodyProps) {
   const language = useLanguage();
 
-  let extraUrl:string = '';
+  let extraUrl: string = "";
   const unitConnections = currentUnit?.connections;
   if (unitConnections) {
-    let otherInfo = unitConnections.find(connection => {
-      return connection.section_type === "OTHER_INFO"
+    let otherInfo = unitConnections.find((connection) => {
+      return connection.section_type === "OTHER_INFO";
     });
     extraUrl = otherInfo?.www.fi!;
   }

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -171,6 +171,22 @@ const unit = {
       tags: [
         "#valvonta"
       ]
+    },
+    {
+      id: 12514,
+      section_type: "OTHER_INFO",
+      name: {
+        fi: "Lämmitetty",
+        sv: "Uppvärmd",
+        en: "Heated"
+      },
+      www: null,
+      email: null,
+      phone: null,
+      contact_person: null,
+      tags: [
+        "#lämmitys"
+      ]
     }
   ],
   observations: [temperatureDataObservation, liveTemperatureDataObservation],
@@ -298,9 +314,25 @@ describe("<UnitDetails />", () => {
   describe("when control data is not available", () => {
     it("should not be displayed", () => {
       const wrapper = getWrapper({}, {
-        connections: unit.connections.filter((con) => con.name.fi !== "Valvottu")
+        connections: unit.connections.filter((con) => con.tags === undefined)
       });
       expect(wrapper.text().includes("Valvonta: Valvottu")).toEqual(false);
+    });   
+  })
+
+  describe("when heating data is available", () => {
+    it("should be displayed", () => {
+      const wrapper = getWrapper();
+      expect(wrapper.text().includes("Lämmitys: Lämmitetty")).toEqual(true);
+    });   
+  });
+
+  describe("when heating data is not available", () => {
+    it("should not be displayed", () => {
+      const wrapper = getWrapper({}, {
+        connections: unit.connections.filter((con) => con.tags === undefined)
+      });
+      expect(wrapper.text().includes("Lämmitys: Lämmitetty")).toEqual(false);
     });   
   })
 

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -156,6 +156,22 @@ const unit = {
       contact_person: null,
       unit: 40142,
     },
+    {
+      id: 12513,
+      section_type: "OTHER_INFO",
+      name: {
+        fi: "Valvottu",
+        sv: "Kontrollerade",
+        en: "Controlled"
+      },
+      www: null,
+      email: null,
+      phone: null,
+      contact_person: null,
+      tags: [
+        "#valvonta"
+      ]
+    }
   ],
   observations: [temperatureDataObservation, liveTemperatureDataObservation],
   extra: {
@@ -271,6 +287,22 @@ describe("<UnitDetails />", () => {
       });
     });
   });
+
+  describe("when control data is available", () => {
+    it("should be displayed", () => {
+      const wrapper = getWrapper();
+      expect(wrapper.text().includes("Valvonta: Valvottu")).toEqual(true);
+    });   
+  });
+
+  describe("when control data is not available", () => {
+    it("should not be displayed", () => {
+      const wrapper = getWrapper({}, {
+        connections: unit.connections.filter((con) => con.name.fi !== "Valvottu")
+      });
+      expect(wrapper.text().includes("Valvonta: Valvottu")).toEqual(false);
+    });   
+  })
 
   it("should render extras correctly", () => {
     const wrapper = getWrapper();

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -42,6 +42,7 @@ type Translatable<T = string> = {
 
 export const UnitConnectionTags = {
   CONTROL: "#valvonta",
+  HEATING: "#lämmitys",
 } as const;
 
 export type UnitConnection = {

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -40,6 +40,13 @@ type Translatable<T = string> = {
   en: T;
 };
 
+export type UnitConnection = {
+  section_type: string;
+  name: Translatable<string>;
+  www: Translatable<string>;
+  tags: Array<string>;
+};
+
 export type Unit = {
   id: string;
   name: Translatable<string>;
@@ -69,11 +76,7 @@ export type Unit = {
     time: string;
   }>;
   www: Translatable<string>;
-  connections: Array<{
-    section_type: string;
-    name: Translatable<string>;
-    www: Translatable<string>;
-  }>;
+  connections: Array<UnitConnection>;
   picture_url?: string;
   extra: Record<string, string | number>;
 };

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -40,6 +40,10 @@ type Translatable<T = string> = {
   en: T;
 };
 
+export const UnitConnectionTags = {
+  CONTROL: "#valvonta",
+} as const;
+
 export type UnitConnection = {
   section_type: string;
   name: Translatable<string>;

--- a/src/domain/unit/unitHelpers.ts
+++ b/src/domain/unit/unitHelpers.ts
@@ -31,6 +31,7 @@ import {
   StatusFilter,
   SportFilters,
   SeasonDelimiter,
+  UnitConnection,
 } from "./unitConstants";
 
 export const getFetchUnitsRequest = (params: Record<string, any>) =>
@@ -168,6 +169,15 @@ export const getObservationTime = (observation: Record<string, any>) =>
 
 export const enumerableQuality = (quality: string): number =>
   QualityEnum[quality] ? QualityEnum[quality] : Number.MAX_VALUE;
+
+export const getConnectionByTag = (
+  unit: Unit,
+  tag: string
+): UnitConnection | undefined => {
+  return unit.connections.find(
+    (connection) => connection.tags && connection.tags.includes(tag)
+  );
+};
 
 /**
  * ICONS


### PR DESCRIPTION
## Description
Add heating information under Info section in unit detail view. Information is shown only if unit data contains a connection with `#lämmitys` tag.

Be aware, that this PR is based on #140 so it is probably best to merge that first.

## Context
Customer wanted this information to be visible.

<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[HULK-4](https://helsinkisolutionoffice.atlassian.net/browse/HULK-4)

## How Has This Been Tested?
There is a new unit test and I also tested it with mocked API.

## Manual Testing Instructions for Reviewers
Because #lämmitys tag data is not yet available in the backend, you have to mock the API using a tool like [Mockoon](https://mockoon.com/). Make sure all languages are working.

## Screenshots
![Screenshot 2022-07-15 at 11 48 14](https://user-images.githubusercontent.com/14893875/179189519-4f795ec2-0699-4b69-8a7f-81eab48ac558.png)

