### PR TITLE
HULK-8 - Expandable unit details on mobile devices

### DIFF
--- a/src/domain/home/HomeContainer.tsx
+++ b/src/domain/home/HomeContainer.tsx
@@ -1,5 +1,5 @@
 import className from "classnames";
-import { useCallback, useRef, ReactNode } from "react";
+import { useCallback, useRef, ReactNode, useState } from "react";
 import { Map as RLMap } from "react-leaflet";
 import { Switch, useRouteMatch, Route } from "react-router-dom";
 
@@ -56,6 +56,11 @@ function HomeContainer() {
   const mapRef = useRef<RLMap | null>(null);
   const leafletElementRef = useRef<L.Map | null>(null);
   const isMobile = useIsMobile();
+  const [isUnitDetailsExpanded, setIsUnitDetailsExpanded] = useState(false)
+
+  const toggleIsUnitDetailsExpanded = () => {
+    setIsUnitDetailsExpanded(!isUnitDetailsExpanded)
+  }
 
   const handleOnViewChange = useCallback((coordinates) => {
     leafletElementRef.current?.setView(coordinates);
@@ -115,7 +120,7 @@ function HomeContainer() {
             exact
             path={routerPaths.unitDetails}
             render={() => (
-              <UnitDetails onCenterMapToUnit={handleCenterMapToUnit} />
+              <UnitDetails onCenterMapToUnit={handleCenterMapToUnit} isExpanded={isUnitDetailsExpanded} toggleIsExpanded={toggleIsUnitDetailsExpanded} />
             )}
           />
           <Route

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -59,7 +59,8 @@
     "MAP_BUTTON": "Show results on map",
     "LIST_BUTTON": "Show results on map and on the list",
     "CONTROL": "Control",
-    "HEATING": "Heating"
+    "HEATING": "Heating",
+    "LIGHTED": "Lighting"
   },
   "UNIT_BROWSER": {
     "LOADING": "Loading the object",

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -58,7 +58,8 @@
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Show results on map",
     "LIST_BUTTON": "Show results on map and on the list",
-    "CONTROL": "Control"
+    "CONTROL": "Control",
+    "HEATING": "Heating"
   },
   "UNIT_BROWSER": {
     "LOADING": "Loading the object",

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -60,7 +60,8 @@
     "LIST_BUTTON": "Show results on map and on the list",
     "CONTROL": "Control",
     "HEATING": "Heating",
-    "LIGHTED": "Lighting"
+    "LIGHTED": "Lighting",
+    "DRESSING_ROOM": "Dressing room"
   },
   "UNIT_BROWSER": {
     "LOADING": "Loading the object",

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -35,6 +35,7 @@
   "UNIT_DETAILS": {
     "FURTHER_INFO": "Further information",
     "SHOW_MORE": "Show more",
+    "SHOW_LESS": "Show less",
     "STATUS": "Condition",
     "UNKNOWN": "Unknown",
     "UPDATED": "Updated",
@@ -85,6 +86,7 @@
     "WATER_TEMPERATURE_SENSOR": "Water temperature sensor",
     "CLOSE": "Close",
     "SEE_ON_SERVICE_MAP": "More information on the Service Map"
+    
   },
   "SEARCH": {
     "SEARCH": "Search",

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -57,7 +57,8 @@
     "PHONE": "Phone",
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Show results on map",
-    "LIST_BUTTON": "Show results on map and on the list"
+    "LIST_BUTTON": "Show results on map and on the list",
+    "CONTROL": "Control"
   },
   "UNIT_BROWSER": {
     "LOADING": "Loading the object",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -57,7 +57,8 @@
     "PHONE": "Puhelinnumero",
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Näytä tulokset kartalla",
-    "LIST_BUTTON": "Näytä tulokset kartalla ja listana"
+    "LIST_BUTTON": "Näytä tulokset kartalla ja listana",
+    "CONTROL": "Valvonta"
   },
   "UNIT_BROWSER": {
     "LOADING": "Ladataan kohdetta...",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -35,6 +35,7 @@
   "UNIT_DETAILS": {
     "FURTHER_INFO": "Lisää tietoa",
     "SHOW_MORE": "Näytä enemmän",
+    "SHOW_LESS": "Näytä vähemmän",
     "STATUS": "Kunto",
     "UNKNOWN": "Tuntematon",
     "UPDATED": "Päivitetty",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -60,7 +60,8 @@
     "LIST_BUTTON": "Näytä tulokset kartalla ja listana",
     "CONTROL": "Valvonta",
     "HEATING": "Lämmitys",
-    "LIGHTED": "Valaistus"
+    "LIGHTED": "Valaistus",
+    "DRESSING_ROOM": "Pukukoppi"
   },
   "UNIT_BROWSER": {
     "LOADING": "Ladataan kohdetta...",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -59,7 +59,8 @@
     "MAP_BUTTON": "Näytä tulokset kartalla",
     "LIST_BUTTON": "Näytä tulokset kartalla ja listana",
     "CONTROL": "Valvonta",
-    "HEATING": "Lämmitys"
+    "HEATING": "Lämmitys",
+    "LIGHTED": "Valaistus"
   },
   "UNIT_BROWSER": {
     "LOADING": "Ladataan kohdetta...",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -58,7 +58,8 @@
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Näytä tulokset kartalla",
     "LIST_BUTTON": "Näytä tulokset kartalla ja listana",
-    "CONTROL": "Valvonta"
+    "CONTROL": "Valvonta",
+    "HEATING": "Lämmitys"
   },
   "UNIT_BROWSER": {
     "LOADING": "Ladataan kohdetta...",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -60,7 +60,8 @@
     "LIST_BUTTON": "Visa resultat på karta och i listan",
     "CONTROL": "Kontrollera",
     "HEATING": "Uppvärmning",
-    "LIGHTED": "Upplysning"
+    "LIGHTED": "Upplysning",
+    "DRESSING_ROOM": "Omklädningsrum"
   },
   "UNIT_BROWSER": {
     "LOADING": "Laddar objekt",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -58,7 +58,8 @@
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Visa resultat på karta",
     "LIST_BUTTON": "Visa resultat på karta och i listan",
-    "CONTROL": "Kontrollera"
+    "CONTROL": "Kontrollera",
+    "HEATING": "Uppvärmning"
   },
   "UNIT_BROWSER": {
     "LOADING": "Laddar objekt",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -35,6 +35,7 @@
   "UNIT_DETAILS": {
     "FURTHER_INFO": "Ytterligare upplysningar",
     "SHOW_MORE": "Visa mer",
+    "SHOW_LESS": "Visa mindre",
     "STATUS": "Skick",
     "UNKNOWN": "Okänt",
     "UPDATED": "Uppdaterad",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -59,7 +59,8 @@
     "MAP_BUTTON": "Visa resultat på karta",
     "LIST_BUTTON": "Visa resultat på karta och i listan",
     "CONTROL": "Kontrollera",
-    "HEATING": "Uppvärmning"
+    "HEATING": "Uppvärmning",
+    "LIGHTED": "Upplysning"
   },
   "UNIT_BROWSER": {
     "LOADING": "Laddar objekt",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -57,7 +57,8 @@
     "PHONE": "Telefon",
     "TMP_MESSAGE": "",
     "MAP_BUTTON": "Visa resultat på karta",
-    "LIST_BUTTON": "Visa resultat på karta och i listan"
+    "LIST_BUTTON": "Visa resultat på karta och i listan",
+    "CONTROL": "Kontrollera"
   },
   "UNIT_BROWSER": {
     "LOADING": "Laddar objekt",

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -25,11 +25,12 @@ import UnitObservationStatus, {
   StatusUpdatedAgo,
 } from "../UnitObservationStatus";
 import * as fromUnit from "../state/selectors";
-import { Unit } from "../unitConstants";
+import { Unit, UnitConnectionTags } from "../unitConstants";
 import {
   createPalvelukarttaUrl,
   createReittiopasUrl,
   getAttr,
+  getConnectionByTag,
   getObservation,
   getObservationTime,
   getOpeningHours,
@@ -158,8 +159,10 @@ function LocationInfo({ unit }: LocationInfoProps) {
     unitExtraLipasSkiTrackFreestyle ||
     unitExtraLipasSkiTrackTraditional;
 
+  const unitControlConnection = getConnectionByTag(unit, UnitConnectionTags.CONTROL)
+
   // Should show info if at least some data is present
-  if (!(unit.phone || unit.url || hasExtras)) {
+  if (!(unit.phone || unit.url || hasExtras || unitControlConnection)) {
     return null;
   }
 
@@ -189,6 +192,12 @@ function LocationInfo({ unit }: LocationInfoProps) {
           ]
             .filter((item) => item)
             .join(", ")}
+        </p>
+      )}
+      {unitControlConnection !== undefined && (
+        <p className="no-margin">
+          {`${t("UNIT_DETAILS.CONTROL")}`}:{" "}
+          {getAttr(unitControlConnection.name, language)}
         </p>
       )}
       {unit.phone && (

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -1,3 +1,4 @@
+import { IconAngleDown } from "hds-react";
 import get from "lodash/get";
 import has from "lodash/has";
 import { ReactNode, useEffect } from "react";
@@ -103,6 +104,22 @@ export function Header({ unit, services, isLoading }: HeaderProps) {
       ) : null}
     </div>
   );
+}
+
+type MobileFooterProps = {
+  toggleExpand: () => void;
+  isExpanded: boolean;
+}
+export function MobileFooter({ toggleExpand, isExpanded }: MobileFooterProps) {
+  const { t } = useTranslation();
+  const footerText = isExpanded ? t("UNIT_DETAILS.SHOW_LESS") : t("UNIT_DETAILS.SHOW_MORE");
+  return (
+  <div className="unit-details-mobile-footer">
+    <div className="unit-details-mobile-footer-expander" onClick={toggleExpand}>
+        {footerText}
+        <IconAngleDown className={ isExpanded ? "unit-details-mobile-footer-icon-expanded" : "unit-details-mobile-footer-icon"} />
+      </div>
+  </div>)
 }
 
 type LocationStateProps = {
@@ -475,9 +492,11 @@ function findAlternatePathname(pathname: string, unit: Unit, language: string) {
 
 type Props = {
   onCenterMapToUnit: (unit: Unit) => void;
+  isExpanded: boolean;
+  toggleIsExpanded: () => void;
 };
 
-function UnitDetails({ onCenterMapToUnit }: Props) {
+function UnitDetails({ onCenterMapToUnit, isExpanded, toggleIsExpanded }: Props) {
   const language = useLanguage();
   const { t } = useTranslation();
   const { pathname } = useLocation();
@@ -545,7 +564,7 @@ function UnitDetails({ onCenterMapToUnit }: Props) {
           unit?.description ? getAttr(unit?.description, language) : undefined
         }
         image={unit?.picture_url}
-        className="unit-container"
+        className={isExpanded ? "unit-container expanded" : "unit-container"}
       >
         <Header unit={unit} services={services} isLoading={isLoading} />
         <SingleUnitBody
@@ -557,6 +576,7 @@ function UnitDetails({ onCenterMapToUnit }: Props) {
           palvelukarttaUrl={palvelukarttaUrl}
         />
       </Page>
+      <MobileFooter toggleExpand={toggleIsExpanded} isExpanded={isExpanded} />
     </>
   );
 }

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -171,7 +171,10 @@ function LocationInfo({ unit }: LocationInfoProps) {
     unit,
     UnitConnectionTags.LIGHTED
   )
-
+  const unitDressingRoomConnection = getConnectionByTag(
+    unit,
+    UnitConnectionTags.DRESSING_ROOM
+  )
   // Should show info if at least some data is present
   if (
     !(
@@ -180,7 +183,8 @@ function LocationInfo({ unit }: LocationInfoProps) {
       hasExtras ||
       unitControlConnection ||
       unitHeatedConnection ||
-      unitLightedConnection
+      unitLightedConnection ||
+      unitDressingRoomConnection
     )
   ) {
     return null;
@@ -230,6 +234,12 @@ function LocationInfo({ unit }: LocationInfoProps) {
         <p className="no-margin">
           {`${t("UNIT_DETAILS.LIGHTED")}`}:{" "}
           {getAttr(unitLightedConnection.name, language)}
+        </p>
+      )}
+      {unitDressingRoomConnection !== undefined && (
+        <p className="no-margin">
+          {`${t("UNIT_DETAILS.DRESSING_ROOM")}`}:{" "}
+          {getAttr(unitDressingRoomConnection.name, language)}
         </p>
       )}
       {unit.phone && (

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -167,6 +167,10 @@ function LocationInfo({ unit }: LocationInfoProps) {
     unit,
     UnitConnectionTags.HEATING
   );
+  const unitLightedConnection = getConnectionByTag(
+    unit,
+    UnitConnectionTags.LIGHTED
+  )
 
   // Should show info if at least some data is present
   if (
@@ -175,7 +179,8 @@ function LocationInfo({ unit }: LocationInfoProps) {
       unit.url ||
       hasExtras ||
       unitControlConnection ||
-      unitHeatedConnection
+      unitHeatedConnection ||
+      unitLightedConnection
     )
   ) {
     return null;
@@ -219,6 +224,12 @@ function LocationInfo({ unit }: LocationInfoProps) {
         <p className="no-margin">
           {`${t("UNIT_DETAILS.HEATING")}`}:{" "}
           {getAttr(unitHeatedConnection.name, language)}
+        </p>
+      )}
+      {unitLightedConnection !== undefined && (
+        <p className="no-margin">
+          {`${t("UNIT_DETAILS.LIGHTED")}`}:{" "}
+          {getAttr(unitLightedConnection.name, language)}
         </p>
       )}
       {unit.phone && (

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -159,10 +159,25 @@ function LocationInfo({ unit }: LocationInfoProps) {
     unitExtraLipasSkiTrackFreestyle ||
     unitExtraLipasSkiTrackTraditional;
 
-  const unitControlConnection = getConnectionByTag(unit, UnitConnectionTags.CONTROL)
+  const unitControlConnection = getConnectionByTag(
+    unit,
+    UnitConnectionTags.CONTROL
+  );
+  const unitHeatedConnection = getConnectionByTag(
+    unit,
+    UnitConnectionTags.HEATING
+  );
 
   // Should show info if at least some data is present
-  if (!(unit.phone || unit.url || hasExtras || unitControlConnection)) {
+  if (
+    !(
+      unit.phone ||
+      unit.url ||
+      hasExtras ||
+      unitControlConnection ||
+      unitHeatedConnection
+    )
+  ) {
     return null;
   }
 
@@ -198,6 +213,12 @@ function LocationInfo({ unit }: LocationInfoProps) {
         <p className="no-margin">
           {`${t("UNIT_DETAILS.CONTROL")}`}:{" "}
           {getAttr(unitControlConnection.name, language)}
+        </p>
+      )}
+      {unitHeatedConnection !== undefined && (
+        <p className="no-margin">
+          {`${t("UNIT_DETAILS.HEATING")}`}:{" "}
+          {getAttr(unitHeatedConnection.name, language)}
         </p>
       )}
       {unit.phone && (
@@ -251,7 +272,11 @@ type LocationRouteProps = {
   extraUrl?: string;
 };
 
-function LocationRoute({ routeUrl, palvelukarttaUrl, extraUrl }: LocationRouteProps) {
+function LocationRoute({
+  routeUrl,
+  palvelukarttaUrl,
+  extraUrl,
+}: LocationRouteProps) {
   const { t } = useTranslation();
 
   return (
@@ -381,11 +406,11 @@ export function SingleUnitBody({
 }: SingleUnitBodyProps) {
   const language = useLanguage();
 
-  let extraUrl:string = '';
+  let extraUrl: string = "";
   const unitConnections = currentUnit?.connections;
   if (unitConnections) {
-    let otherInfo = unitConnections.find(connection => {
-      return connection.section_type === "OTHER_INFO"
+    let otherInfo = unitConnections.find((connection) => {
+      return connection.section_type === "OTHER_INFO";
     });
     extraUrl = otherInfo?.www.fi!;
   }

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -203,6 +203,22 @@ const unit = {
       tags: [
         "#valaisu"
       ]
+    },
+    {
+      id: 12516,
+      section_type: "OTHER_INFO",
+      name: {
+        fi: "Pukukopit 2kpl, avoinna 24h",
+        sv: "Omklädningsrum 2st, öppet 24h",
+        en: "Dressing rooms 2pcs, open 24h"
+      },
+      www: null,
+      email: null,
+      phone: null,
+      contact_person: null,
+      tags: [
+        "#pukukoppi"
+      ]
     }
   ],
   observations: [temperatureDataObservation, liveTemperatureDataObservation],
@@ -368,6 +384,25 @@ describe("<UnitDetails />", () => {
         }
       );
       expect(wrapper.text().includes("Valaistus: Valaistu")).toEqual(false);
+    });
+  });
+
+  describe("when dressing room data is available", () => {
+    it("should be displayed", () => {
+      const wrapper = getWrapper();
+      expect(wrapper.text().includes("Pukukoppi: Pukukopit 2kpl, avoinna 24h")).toEqual(true);
+    });
+  });
+
+  describe("when dressing room data is not available", () => {
+    it("should not be displayed", () => {
+      const wrapper = getWrapper(
+        {},
+        {
+          connections: unit.connections.filter((con) => con.tags === undefined),
+        }
+      );
+      expect(wrapper.text().includes("Pukukoppi: Pukukopit 2kpl, avoinna 24h")).toEqual(false);
     });
   });
 

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -187,6 +187,22 @@ const unit = {
       tags: [
         "#lämmitys"
       ]
+    },
+    {
+      id: 12515,
+      section_type: "OTHER_INFO",
+      name: {
+        fi: "Valaistu",
+        sv: "Upplyst",
+        en: "Lighted"
+      },
+      www: null,
+      email: null,
+      phone: null,
+      contact_person: null,
+      tags: [
+        "#valaisu"
+      ]
     }
   ],
   observations: [temperatureDataObservation, liveTemperatureDataObservation],
@@ -335,6 +351,25 @@ describe("<UnitDetails />", () => {
       expect(wrapper.text().includes("Lämmitys: Lämmitetty")).toEqual(false);
     });   
   })
+
+  describe("when lighting data is available", () => {
+    it("should be displayed", () => {
+      const wrapper = getWrapper();
+      expect(wrapper.text().includes("Valaistus: Valaistu")).toEqual(true);
+    });
+  });
+
+  describe("when lighting data is not available", () => {
+    it("should not be displayed", () => {
+      const wrapper = getWrapper(
+        {},
+        {
+          connections: unit.connections.filter((con) => con.tags === undefined),
+        }
+      );
+      expect(wrapper.text().includes("Valaistus: Valaistu")).toEqual(false);
+    });
+  });
 
   it("should render extras correctly", () => {
     const wrapper = getWrapper();

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -171,6 +171,22 @@ const unit = {
       tags: [
         "#valvonta"
       ]
+    },
+    {
+      id: 12514,
+      section_type: "OTHER_INFO",
+      name: {
+        fi: "Lämmitetty",
+        sv: "Uppvärmd",
+        en: "Heated"
+      },
+      www: null,
+      email: null,
+      phone: null,
+      contact_person: null,
+      tags: [
+        "#lämmitys"
+      ]
     }
   ],
   observations: [temperatureDataObservation, liveTemperatureDataObservation],
@@ -298,9 +314,25 @@ describe("<UnitDetails />", () => {
   describe("when control data is not available", () => {
     it("should not be displayed", () => {
       const wrapper = getWrapper({}, {
-        connections: unit.connections.filter((con) => con.name.fi !== "Valvottu")
+        connections: unit.connections.filter((con) => con.tags === undefined)
       });
       expect(wrapper.text().includes("Valvonta: Valvottu")).toEqual(false);
+    });   
+  })
+
+  describe("when heating data is available", () => {
+    it("should be displayed", () => {
+      const wrapper = getWrapper();
+      expect(wrapper.text().includes("Lämmitys: Lämmitetty")).toEqual(true);
+    });   
+  });
+
+  describe("when heating data is not available", () => {
+    it("should not be displayed", () => {
+      const wrapper = getWrapper({}, {
+        connections: unit.connections.filter((con) => con.tags === undefined)
+      });
+      expect(wrapper.text().includes("Lämmitys: Lämmitetty")).toEqual(false);
     });   
   })
 

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -156,6 +156,22 @@ const unit = {
       contact_person: null,
       unit: 40142,
     },
+    {
+      id: 12513,
+      section_type: "OTHER_INFO",
+      name: {
+        fi: "Valvottu",
+        sv: "Kontrollerade",
+        en: "Controlled"
+      },
+      www: null,
+      email: null,
+      phone: null,
+      contact_person: null,
+      tags: [
+        "#valvonta"
+      ]
+    }
   ],
   observations: [temperatureDataObservation, liveTemperatureDataObservation],
   extra: {
@@ -271,6 +287,22 @@ describe("<UnitDetails />", () => {
       });
     });
   });
+
+  describe("when control data is available", () => {
+    it("should be displayed", () => {
+      const wrapper = getWrapper();
+      expect(wrapper.text().includes("Valvonta: Valvottu")).toEqual(true);
+    });   
+  });
+
+  describe("when control data is not available", () => {
+    it("should not be displayed", () => {
+      const wrapper = getWrapper({}, {
+        connections: unit.connections.filter((con) => con.name.fi !== "Valvottu")
+      });
+      expect(wrapper.text().includes("Valvonta: Valvottu")).toEqual(false);
+    });   
+  })
 
   it("should render extras correctly", () => {
     const wrapper = getWrapper();

--- a/src/domain/unit/details/_unitDetails.scss
+++ b/src/domain/unit/details/_unitDetails.scss
@@ -1,7 +1,13 @@
 .unit-container {
-  max-height: 60vh;
+  max-height: 30vh;
   padding: 10px;
   overflow-y: auto;
+  transition: max-height 0.5s ease-in-out;
+
+  &.expanded {
+    max-height: 80vh;
+    transition: max-height 0.5s ease-in-out;
+  }
 
   @media only screen and (min-width: 768px) {
     max-height: unset;
@@ -109,6 +115,26 @@
   &-close-button {
     &:hover {
       cursor: pointer;
+    }
+  }
+}
+
+.unit-details-mobile-footer {
+  @media only screen and (min-width: 768px) {
+    display: none;
+  }
+
+  padding: 10px;
+  color: var(--color-info-light);
+  text-align: right;
+  
+  &-icon {
+    transform: rotate(0deg);
+    transition: transform 0.5s ease-in-out;
+
+    &-expanded {
+      transform: rotate(-180deg);
+      transition: transform 0.5s ease-in-out
     }
   }
 }

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -44,6 +44,7 @@ export const UnitConnectionTags = {
   CONTROL: "#valvonta",
   HEATING: "#lämmitys",
   LIGHTED: "#valaisu",
+  DRESSING_ROOM: "#pukukoppi",
 } as const;
 
 export type UnitConnection = {

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -42,6 +42,7 @@ type Translatable<T = string> = {
 
 export const UnitConnectionTags = {
   CONTROL: "#valvonta",
+  HEATING: "#lämmitys",
 } as const;
 
 export type UnitConnection = {

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -40,6 +40,13 @@ type Translatable<T = string> = {
   en: T;
 };
 
+export type UnitConnection = {
+  section_type: string;
+  name: Translatable<string>;
+  www: Translatable<string>;
+  tags: Array<string>;
+};
+
 export type Unit = {
   id: string;
   name: Translatable<string>;
@@ -69,11 +76,7 @@ export type Unit = {
     time: string;
   }>;
   www: Translatable<string>;
-  connections: Array<{
-    section_type: string;
-    name: Translatable<string>;
-    www: Translatable<string>;
-  }>;
+  connections: Array<UnitConnection>;
   picture_url?: string;
   extra: Record<string, string | number>;
 };

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -40,6 +40,10 @@ type Translatable<T = string> = {
   en: T;
 };
 
+export const UnitConnectionTags = {
+  CONTROL: "#valvonta",
+} as const;
+
 export type UnitConnection = {
   section_type: string;
   name: Translatable<string>;

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -43,6 +43,7 @@ type Translatable<T = string> = {
 export const UnitConnectionTags = {
   CONTROL: "#valvonta",
   HEATING: "#lämmitys",
+  LIGHTED: "#valaisu",
 } as const;
 
 export type UnitConnection = {

--- a/src/domain/unit/unitHelpers.ts
+++ b/src/domain/unit/unitHelpers.ts
@@ -31,6 +31,7 @@ import {
   StatusFilter,
   SportFilters,
   SeasonDelimiter,
+  UnitConnection,
 } from "./unitConstants";
 
 export const getFetchUnitsRequest = (params: Record<string, any>) =>
@@ -168,6 +169,15 @@ export const getObservationTime = (observation: Record<string, any>) =>
 
 export const enumerableQuality = (quality: string): number =>
   QualityEnum[quality] ? QualityEnum[quality] : Number.MAX_VALUE;
+
+export const getConnectionByTag = (
+  unit: Unit,
+  tag: string
+): UnitConnection | undefined => {
+  return unit.connections.find(
+    (connection) => connection.tags && connection.tags.includes(tag)
+  );
+};
 
 /**
  * ICONS


### PR DESCRIPTION
## Description
Change unit details view to be expandable on mobile devices.

`IsExpanded` state is stored on the parent controller so that user don't have to expand the view every time a new unit is selected. There is a simple animation when component is expanded or collapsed. Also, the icon is rotated 180 degrees to indicate the element's movement direction.

## Context
On smaller screen the details views hides most of the map which makes using the service a bit tricky. 
[HULK-8](https://helsinkisolutionoffice.atlassian.net/browse/HULK-8)

## How Has This Been Tested?
Manual testing. Unfortunately my frontend testing skills are not good enough to write unit tests for this kinds of features 🙈 

## Manual Testing Instructions for Reviewers
Open the UI with a mobile device or browser device emulator. Screen width have to be smaller than `768px`. Make sure expanding and collapsing works as expected. Verify that expand button is not visible on bigger screens. 

## Screenshots
![resizing](https://user-images.githubusercontent.com/14893875/179702567-a70a5478-4303-4cd8-9523-1fb36b8c12fa.gif)

