### PR TITLE
Dynamic App wide notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,12 +7,3 @@ REACT_APP_API_URL=https://api.hel.fi/servicemap/v2
 REACT_APP_DIGITRANSIT_API_URL=https://api.digitransit.fi/geocoding/v1
 
 REACT_APP_APP_NAME=outdoors-sports-map
-
-# Site wide notification settings
-REACT_APP_SITE_WIDE_NOTIFICATION_ENABLED=true
-REACT_APP_SITE_WIDE_NOTIFICATION_TITLE_FI="Otsikko"
-REACT_APP_SITE_WIDE_NOTIFICATION_TITLE_SV="Titel"
-REACT_APP_SITE_WIDE_NOTIFICATION_TITLE_EN="Title"
-REACT_APP_SITE_WIDE_NOTIFICATION_FI="FI: Lorem ipsum dolor sit amet, consectetur adipsicing elit."
-REACT_APP_SITE_WIDE_NOTIFICATION_SV="SV: Lorem ipsum dolor sit amet, consectetur adipsicing elit."
-REACT_APP_SITE_WIDE_NOTIFICATION_EN="EN: Lorem ipsum dolor sit amet, consectetur adipsicing elit."

--- a/src/domain/app/appWideNotification/AppWideNotification.tsx
+++ b/src/domain/app/appWideNotification/AppWideNotification.tsx
@@ -1,56 +1,43 @@
 import { Notification } from "hds-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector,
-//  useSelector
-} from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import { fetchAppWideNotifications } from "./actions";
 import { getData } from "./selectors";
-//import { getAll } from "./selectors";
 
 const IS_OPEN_KEY = "ulkoliikunta:isAppWideNotificationOpen";
-
-function getInitialValue(
-  sessionStorageValue: string | null,
-  isNotificationEnabled: boolean | null
-) {
-  if (sessionStorageValue) {
-    return sessionStorage.getItem(IS_OPEN_KEY) === "true";
-  }
-
-  return isNotificationEnabled === true;
-}
 
 export function AppWideNotification() {
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(fetchAppWideNotifications({}));
-  }, [])
+  }, [dispatch])
 
-  const notification = useSelector(getData);
-  console.log('AppWideNotification', notification);
-
+  const data = useSelector(getData);
+  const notification = data && data[0];
+  
   const notificationContentTranslations: Record<string, string | undefined> = {
-    fi: process.env.REACT_APP_SITE_WIDE_NOTIFICATION_FI,
-    sv: process.env.REACT_APP_SITE_WIDE_NOTIFICATION_SV,
-    en: process.env.REACT_APP_SITE_WIDE_NOTIFICATION_EN,
+    fi: notification ? notification.content.fi : '',
+    sv: notification ? notification.content.sv : '',
+    en: notification ? notification.content.en : '',
   };
   const notificationContentTitleTranslations: Record<string, string | undefined> = {
-    fi: process.env.REACT_APP_SITE_WIDE_NOTIFICATION_TITLE_FI,
-    sv: process.env.REACT_APP_SITE_WIDE_NOTIFICATION_TITLE_SV,
-    en: process.env.REACT_APP_SITE_WIDE_NOTIFICATION_TITLE_EN,
+    fi: notification ? notification.title.fi : '',
+    sv: notification ? notification.title.sv : '',
+    en: notification ? notification.title.en : '',
   };
-  const isNotificationEnabledEnvVariable =
-    process.env.REACT_APP_SITE_WIDE_NOTIFICATION_ENABLED;
-  const isNotificationEnabled = isNotificationEnabledEnvVariable
-    ? Boolean(JSON.parse(isNotificationEnabledEnvVariable))
-    : null;
 
-  const [isOpen, setOpen] = useState(() =>
-    getInitialValue(sessionStorage.getItem(IS_OPEN_KEY), isNotificationEnabled)
-  );
+  const isNotificationEnabled = notification ? true : false;
+
+  const [isOpen, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (isNotificationEnabled&& sessionStorage.getItem(IS_OPEN_KEY) !== notification.id.toString()) {
+      setOpen(true); 
+    }
+  }, [isNotificationEnabled, notification])
 
   const {
     t,
@@ -67,10 +54,8 @@ export function AppWideNotification() {
 
   const handleClose = () => {
     setOpen(false);
-    sessionStorage.setItem(IS_OPEN_KEY, false.toString());
+    sessionStorage.setItem(IS_OPEN_KEY, notification.id.toString());
   };
-
-  // return <button onClick={() => console.log(useSelector(getData))}></button>
 
   return isOpen ? (
     <Notification

--- a/src/domain/app/appWideNotification/AppWideNotification.tsx
+++ b/src/domain/app/appWideNotification/AppWideNotification.tsx
@@ -8,7 +8,11 @@ import { getData } from "./selectors";
 
 const IS_OPEN_KEY = "ulkoliikunta:isAppWideNotificationOpen";
 
-export function AppWideNotification() {
+type NotificationProps = {
+  initialState?: boolean;
+};
+
+export function AppWideNotification({initialState}: NotificationProps) {
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -31,10 +35,10 @@ export function AppWideNotification() {
 
   const isNotificationEnabled = notification ? true : false;
 
-  const [isOpen, setOpen] = useState(false);
+  const [isOpen, setOpen] = useState(initialState);
 
   useEffect(() => {
-    if (isNotificationEnabled&& sessionStorage.getItem(IS_OPEN_KEY) !== notification.id.toString()) {
+    if (isNotificationEnabled && sessionStorage.getItem(IS_OPEN_KEY) !== notification.id.toString()) {
       setOpen(true); 
     }
   }, [isNotificationEnabled, notification])

--- a/src/domain/app/appWideNotification/AppWideNotification.tsx
+++ b/src/domain/app/appWideNotification/AppWideNotification.tsx
@@ -1,6 +1,12 @@
 import { Notification } from "hds-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useDispatch,
+//  useSelector
+} from "react-redux";
+
+import { fetchAppWideNotifications } from "./actions";
+//import { getAll } from "./selectors";
 
 const IS_OPEN_KEY = "ulkoliikunta:isAppWideNotificationOpen";
 
@@ -16,6 +22,12 @@ function getInitialValue(
 }
 
 export function AppWideNotification() {
+  const dispatch = useDispatch();
+
+  dispatch(fetchAppWideNotifications({}));
+  //const notification = useSelector(getAll);
+  //console.log(notification);
+
   const notificationContentTranslations: Record<string, string | undefined> = {
     fi: process.env.REACT_APP_SITE_WIDE_NOTIFICATION_FI,
     sv: process.env.REACT_APP_SITE_WIDE_NOTIFICATION_SV,

--- a/src/domain/app/appWideNotification/AppWideNotification.tsx
+++ b/src/domain/app/appWideNotification/AppWideNotification.tsx
@@ -1,11 +1,12 @@
 import { Notification } from "hds-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch,
+import { useDispatch, useSelector,
 //  useSelector
 } from "react-redux";
 
 import { fetchAppWideNotifications } from "./actions";
+import { getData } from "./selectors";
 //import { getAll } from "./selectors";
 
 const IS_OPEN_KEY = "ulkoliikunta:isAppWideNotificationOpen";
@@ -24,9 +25,12 @@ function getInitialValue(
 export function AppWideNotification() {
   const dispatch = useDispatch();
 
-  dispatch(fetchAppWideNotifications({}));
-  //const notification = useSelector(getAll);
-  //console.log(notification);
+  useEffect(() => {
+    dispatch(fetchAppWideNotifications({}));
+  }, [])
+
+  const notification = useSelector(getData);
+  console.log('AppWideNotification', notification);
 
   const notificationContentTranslations: Record<string, string | undefined> = {
     fi: process.env.REACT_APP_SITE_WIDE_NOTIFICATION_FI,
@@ -65,6 +69,8 @@ export function AppWideNotification() {
     setOpen(false);
     sessionStorage.setItem(IS_OPEN_KEY, false.toString());
   };
+
+  // return <button onClick={() => console.log(useSelector(getData))}></button>
 
   return isOpen ? (
     <Notification

--- a/src/domain/app/appWideNotification/__tests__/AppWideNotification.test.tsx
+++ b/src/domain/app/appWideNotification/__tests__/AppWideNotification.test.tsx
@@ -2,7 +2,6 @@ import {
   render,
   screen,
 } from "../../../testinLibraryUtils";
-
 import AppWideNotification from "../AppWideNotification";
 
 describe("<AppWideNotification />", () => {

--- a/src/domain/app/appWideNotification/__tests__/AppWideNotification.test.tsx
+++ b/src/domain/app/appWideNotification/__tests__/AppWideNotification.test.tsx
@@ -13,7 +13,7 @@ describe("<AppWideNotification />", () => {
     const {container} = render(<AppWideNotification initialState={false} />);
     expect(container.firstChild).not.toBeTruthy();
   });
-  it("dialog exist and have a close button", () => {
+  it("dialog should exist and have a close button", () => {
     const {container} = render(<AppWideNotification initialState={true} />);
     expect(container.firstChild).toBeTruthy();
     const closeButton = screen.getByRole("button");

--- a/src/domain/app/appWideNotification/__tests__/AppWideNotification.test.tsx
+++ b/src/domain/app/appWideNotification/__tests__/AppWideNotification.test.tsx
@@ -1,78 +1,24 @@
-import React from "react";
-
 import {
   render,
   screen,
-  userEvent,
-  waitForElementToBeRemoved,
-  cleanup,
 } from "../../../testinLibraryUtils";
+
 import AppWideNotification from "../AppWideNotification";
 
-let envStore: any = null;
-
-beforeAll(() => {
-  envStore = process.env;
-});
-
-beforeEach(() => {
-  process.env = envStore;
-});
-
-afterAll(() => {
-  process.env = envStore;
-});
-
-function setupVisibleNotification() {
-  const content = "App notification content";
-  process.env.REACT_APP_SITE_WIDE_NOTIFICATION_ENABLED = "1";
-  process.env.REACT_APP_SITE_WIDE_NOTIFICATION_TITLE_FI = "Ilmoitus";
-  process.env.REACT_APP_SITE_WIDE_NOTIFICATION_FI = content;
-
-  return { content };
-}
-
-test("should not be visible when flag for it is not toggled on", () => {
-  delete process.env.REACT_APP_SITE_WIDE_NOTIFICATION_ENABLED;
-
-  render(<AppWideNotification />);
-
-  expect(
-    screen.queryByRole("heading", { name: "Ilmoitus" })
-  ).not.toBeInTheDocument();
-
-  cleanup();
-  render(<AppWideNotification />);
-  process.env.REACT_APP_SITE_WIDE_NOTIFICATION_ENABLED = "false";
-  expect(
-    screen.queryByRole("heading", { name: "Ilmoitus" })
-  ).not.toBeInTheDocument();
-
-  cleanup();
-  render(<AppWideNotification />);
-  process.env.REACT_APP_SITE_WIDE_NOTIFICATION_ENABLED = "0";
-  expect(
-    screen.queryByRole("heading", { name: "Ilmoitus" })
-  ).not.toBeInTheDocument();
-});
-
-test("should be visible when enabled and has translation", () => {
-  const { content } = setupVisibleNotification();
-
-  render(<AppWideNotification />);
-
-  expect(screen.getByRole("heading", { name: "Ilmoitus" })).toBeInTheDocument();
-  expect(screen.getByText(content)).toBeInTheDocument();
-});
-
-test("should be dismissable", async () => {
-  const { content } = setupVisibleNotification();
-
-  render(<AppWideNotification />);
-
-  expect(screen.queryByText(content)).toBeInTheDocument();
-
-  userEvent.click(screen.getByRole("button", { name: "Sulje" }));
-
-  await waitForElementToBeRemoved(() => screen.queryByText(content));
+describe("<AppWideNotification />", () => {
+  it("dialog should exist", () => {
+    const {container} = render(<AppWideNotification initialState={true} />);
+    expect(container.firstChild).toBeTruthy();
+  });
+  it("dialog should not exist", () => {
+    const {container} = render(<AppWideNotification initialState={false} />);
+    expect(container.firstChild).not.toBeTruthy();
+  });
+  it("dialog exist and have a close button", () => {
+    const {container} = render(<AppWideNotification initialState={true} />);
+    expect(container.firstChild).toBeTruthy();
+    const closeButton = screen.getByRole("button");
+    expect(closeButton).toBeTruthy();
+    expect(closeButton.title).toEqual("Sulje");
+  });
 });

--- a/src/domain/app/appWideNotification/actions.ts
+++ b/src/domain/app/appWideNotification/actions.ts
@@ -2,17 +2,14 @@ import { createAction } from "redux-actions";
 
 import { Action } from "../../../domain/app/appConstants";
 import { ApiResponse } from "../../api/apiConstants";
-import { AppWideNotificationActions, NormalizedAppWideNotificationSchema } from "./appWideNotificationConstants";
+import { AppWideNotificationActions, AppWideNotificationObject } from "./appWideNotificationConstants";
 
 export const fetchAppWideNotifications = (params: Record<string, any>): Action =>
   createAction(AppWideNotificationActions.FETCH)({
     params,
   });
 
-export const receiveAppWideNotifications = (data: NormalizedAppWideNotificationSchema): Action => {
-  //console.log(data);
-  return createAction(AppWideNotificationActions.RECEIVE)(data);
-};
+export const receiveAppWideNotifications = (data: Array<AppWideNotificationObject>): Action => createAction(AppWideNotificationActions.RECEIVE)(data);
 
 export const setFetchError = (error: ApiResponse) =>
   createAction(AppWideNotificationActions.FETCH_ERROR)({

--- a/src/domain/app/appWideNotification/actions.ts
+++ b/src/domain/app/appWideNotification/actions.ts
@@ -1,0 +1,20 @@
+import { createAction } from "redux-actions";
+
+import { Action } from "../../../domain/app/appConstants";
+import { ApiResponse } from "../../api/apiConstants";
+import { AppWideNotificationActions, NormalizedAppWideNotificationSchema } from "./appWideNotificationConstants";
+
+export const fetchAppWideNotifications = (params: Record<string, any>): Action =>
+  createAction(AppWideNotificationActions.FETCH)({
+    params,
+  });
+
+export const receiveAppWideNotifications = (data: NormalizedAppWideNotificationSchema): Action => {
+  //console.log(data);
+  return createAction(AppWideNotificationActions.RECEIVE)(data);
+};
+
+export const setFetchError = (error: ApiResponse) =>
+  createAction(AppWideNotificationActions.FETCH_ERROR)({
+    error,
+  });

--- a/src/domain/app/appWideNotification/actions.ts
+++ b/src/domain/app/appWideNotification/actions.ts
@@ -2,14 +2,21 @@ import { createAction } from "redux-actions";
 
 import { Action } from "../../../domain/app/appConstants";
 import { ApiResponse } from "../../api/apiConstants";
-import { AppWideNotificationActions, AppWideNotificationObject } from "./appWideNotificationConstants";
+import {
+  AppWideNotificationActions,
+  AppWideNotificationObject,
+} from "./appWideNotificationConstants";
 
-export const fetchAppWideNotifications = (params: Record<string, any>): Action =>
+export const fetchAppWideNotifications = (
+  params: Record<string, any>
+): Action =>
   createAction(AppWideNotificationActions.FETCH)({
     params,
   });
 
-export const receiveAppWideNotifications = (data: Array<AppWideNotificationObject>): Action => createAction(AppWideNotificationActions.RECEIVE)(data);
+export const receiveAppWideNotifications = (
+  data: Array<AppWideNotificationObject>
+): Action => createAction(AppWideNotificationActions.RECEIVE)(data);
 
 export const setFetchError = (error: ApiResponse) =>
   createAction(AppWideNotificationActions.FETCH_ERROR)({

--- a/src/domain/app/appWideNotification/appWideNotificationConstants.ts
+++ b/src/domain/app/appWideNotification/appWideNotificationConstants.ts
@@ -10,26 +10,40 @@ export const AppWideNotificationActions = {
 
 export type AppWideNotificationState = {
   isFetching: boolean;
-  byId: Record<string, any>;
+  data: Array<object>;
   fetchError: any;
-  all: Array<string>;
 };
 
-export const appWideNotificationSchema = new schema.Entity<AppWideNotification>("AppWideNotification", undefined, {
-  idAttribute: (value) => value.id.toString(),
-});
+type TranslatedNotificationText = {
+  fi: String;
+  en?: String;
+  sv?: String;
+}
 
-export type AppWideNotification = {
-  id: string;
-};
+export type AppWideNotificationObject = {
+  content: TranslatedNotificationText,
+  external: TranslatedNotificationText,
+  external_url_title: TranslatedNotificationText,
+  lead_paragraph: TranslatedNotificationText,
+  picture_url: String,
+  title: TranslatedNotificationText,
+}
 
-export type NormalizedAppWideNotification = {
-  unit: {
-    [id: number]: NormalizedSchema<AppWideNotification, number>;
-  };
-};
+// export const appWideNotificationSchema = new schema.Entity<AppWideNotification>("AppWideNotification", undefined, {
+//   idAttribute: (value) => value.id.toString(),
+// });
 
-export type NormalizedAppWideNotificationSchema = NormalizedSchema<
-  NormalizedAppWideNotification,
-  number[]
->;
+// export type AppWideNotification = {
+//   id: string;
+// };
+
+// export type NormalizedAppWideNotification = {
+//   unit: {
+//     [id: number]: NormalizedSchema<AppWideNotification, number>;
+//   };
+// };
+
+// export type NormalizedAppWideNotificationSchema = NormalizedSchema<
+//   NormalizedAppWideNotification,
+//   number[]
+// >;

--- a/src/domain/app/appWideNotification/appWideNotificationConstants.ts
+++ b/src/domain/app/appWideNotification/appWideNotificationConstants.ts
@@ -1,5 +1,3 @@
-import { schema, NormalizedSchema } from "normalizr";
-
 import { normalizeActionName } from "../../utils";
 
 export const AppWideNotificationActions = {
@@ -27,23 +25,5 @@ export type AppWideNotificationObject = {
   lead_paragraph: TranslatedNotificationText,
   picture_url: String,
   title: TranslatedNotificationText,
+  id: Number
 }
-
-// export const appWideNotificationSchema = new schema.Entity<AppWideNotification>("AppWideNotification", undefined, {
-//   idAttribute: (value) => value.id.toString(),
-// });
-
-// export type AppWideNotification = {
-//   id: string;
-// };
-
-// export type NormalizedAppWideNotification = {
-//   unit: {
-//     [id: number]: NormalizedSchema<AppWideNotification, number>;
-//   };
-// };
-
-// export type NormalizedAppWideNotificationSchema = NormalizedSchema<
-//   NormalizedAppWideNotification,
-//   number[]
-// >;

--- a/src/domain/app/appWideNotification/appWideNotificationConstants.ts
+++ b/src/domain/app/appWideNotification/appWideNotificationConstants.ts
@@ -8,7 +8,7 @@ export const AppWideNotificationActions = {
 
 export type AppWideNotificationState = {
   isFetching: boolean;
-  data: Array<object>;
+  data: Array<AppWideNotificationObject>;
   fetchError: any;
 };
 

--- a/src/domain/app/appWideNotification/appWideNotificationConstants.ts
+++ b/src/domain/app/appWideNotification/appWideNotificationConstants.ts
@@ -1,0 +1,35 @@
+import { schema, NormalizedSchema } from "normalizr";
+
+import { normalizeActionName } from "../../utils";
+
+export const AppWideNotificationActions = {
+  FETCH: normalizeActionName("appWideNotification/FETCH"),
+  RECEIVE: normalizeActionName("appWideNotification/RECEIVE"),
+  FETCH_ERROR: normalizeActionName("appWideNotification/FETCH_ERROR"),
+};
+
+export type AppWideNotificationState = {
+  isFetching: boolean;
+  byId: Record<string, any>;
+  fetchError: any;
+  all: Array<string>;
+};
+
+export const appWideNotificationSchema = new schema.Entity<AppWideNotification>("AppWideNotification", undefined, {
+  idAttribute: (value) => value.id.toString(),
+});
+
+export type AppWideNotification = {
+  id: string;
+};
+
+export type NormalizedAppWideNotification = {
+  unit: {
+    [id: number]: NormalizedSchema<AppWideNotification, number>;
+  };
+};
+
+export type NormalizedAppWideNotificationSchema = NormalizedSchema<
+  NormalizedAppWideNotification,
+  number[]
+>;

--- a/src/domain/app/appWideNotification/appWideNotificationConstants.ts
+++ b/src/domain/app/appWideNotification/appWideNotificationConstants.ts
@@ -16,14 +16,14 @@ type TranslatedNotificationText = {
   fi: String;
   en?: String;
   sv?: String;
-}
+};
 
 export type AppWideNotificationObject = {
-  content: TranslatedNotificationText,
-  external: TranslatedNotificationText,
-  external_url_title: TranslatedNotificationText,
-  lead_paragraph: TranslatedNotificationText,
-  picture_url: String,
-  title: TranslatedNotificationText,
-  id: Number
-}
+  content: TranslatedNotificationText;
+  external: TranslatedNotificationText;
+  external_url_title: TranslatedNotificationText;
+  lead_paragraph: TranslatedNotificationText;
+  picture_url: String;
+  title: TranslatedNotificationText;
+  id: Number;
+};

--- a/src/domain/app/appWideNotification/reducer.ts
+++ b/src/domain/app/appWideNotification/reducer.ts
@@ -24,31 +24,20 @@ const fetchErrorReducer = handleActions(
   null
 );
 
-const byIdReducer = handleActions(
+const data = handleActions(
   {
     [AppWideNotificationActions.RECEIVE]: (
       state: Record<string, any>,
-      { payload: { entities } }: EntityAction
-    ) => ({ ...entities.appWideNotification }),
+      { payload },
+    ) => payload,
   },
   {}
-);
-
-const all = handleActions(
-  {
-    [AppWideNotificationActions.RECEIVE]: (
-      state: Record<string, any>,
-      { payload: { entities } }: EntityAction
-    ) => [...keys(entities.appWideNotification)],
-  },
-  []
 );
 
 const reducer = combineReducers({
   isFetching: isFetchingReducer,
   fetchError: fetchErrorReducer,
-  byId: byIdReducer,
-  all,
+  data,
 });
 
 export default reducer;

--- a/src/domain/app/appWideNotification/reducer.ts
+++ b/src/domain/app/appWideNotification/reducer.ts
@@ -1,0 +1,54 @@
+import keys from "lodash/keys";
+import { combineReducers } from "redux";
+import { handleActions } from "redux-actions";
+
+import { EntityAction } from "../../../domain/app/appConstants";
+import { AppWideNotificationActions } from "./appWideNotificationConstants";
+
+const isFetchingReducer = handleActions(
+  {
+    [AppWideNotificationActions.FETCH]: () => true,
+    [AppWideNotificationActions.RECEIVE]: () => false,
+    [AppWideNotificationActions.FETCH_ERROR]: () => false,
+  },
+  false
+);
+
+const fetchErrorReducer = handleActions(
+  {
+    [AppWideNotificationActions.FETCH]: () => null,
+    [AppWideNotificationActions.RECEIVE]: () => null,
+    [AppWideNotificationActions.FETCH_ERROR]: (state: Record<string, any> | null, action) =>
+      action?.payload?.error,
+  },
+  null
+);
+
+const byIdReducer = handleActions(
+  {
+    [AppWideNotificationActions.RECEIVE]: (
+      state: Record<string, any>,
+      { payload: { entities } }: EntityAction
+    ) => ({ ...entities.appWideNotification }),
+  },
+  {}
+);
+
+const all = handleActions(
+  {
+    [AppWideNotificationActions.RECEIVE]: (
+      state: Record<string, any>,
+      { payload: { entities } }: EntityAction
+    ) => [...keys(entities.appWideNotification)],
+  },
+  []
+);
+
+const reducer = combineReducers({
+  isFetching: isFetchingReducer,
+  fetchError: fetchErrorReducer,
+  byId: byIdReducer,
+  all,
+});
+
+export default reducer;

--- a/src/domain/app/appWideNotification/reducer.ts
+++ b/src/domain/app/appWideNotification/reducer.ts
@@ -16,8 +16,10 @@ const fetchErrorReducer = handleActions(
   {
     [AppWideNotificationActions.FETCH]: () => null,
     [AppWideNotificationActions.RECEIVE]: () => null,
-    [AppWideNotificationActions.FETCH_ERROR]: (state: Record<string, any> | null, action) =>
-      action?.payload?.error,
+    [AppWideNotificationActions.FETCH_ERROR]: (
+      state: Record<string, any> | null,
+      action
+    ) => action?.payload?.error,
   },
   null
 );
@@ -26,7 +28,7 @@ const data = handleActions(
   {
     [AppWideNotificationActions.RECEIVE]: (
       state: Record<string, any>,
-      { payload },
+      { payload }
     ) => payload,
   },
   {}

--- a/src/domain/app/appWideNotification/reducer.ts
+++ b/src/domain/app/appWideNotification/reducer.ts
@@ -1,8 +1,6 @@
-import keys from "lodash/keys";
 import { combineReducers } from "redux";
 import { handleActions } from "redux-actions";
 
-import { EntityAction } from "../../../domain/app/appConstants";
 import { AppWideNotificationActions } from "./appWideNotificationConstants";
 
 const isFetchingReducer = handleActions(

--- a/src/domain/app/appWideNotification/saga.ts
+++ b/src/domain/app/appWideNotification/saga.ts
@@ -1,36 +1,25 @@
-import { schema } from "normalizr";
 import { all, call, fork, put, takeLatest } from "redux-saga/effects";
 
 import {
   callApi,
   createRequest,
   createUrl,
-  normalizeEntityResults,
 } from "../../api/apiHelpers";
 import { receiveAppWideNotifications, setFetchError } from "./actions";
 import {
   AppWideNotificationActions,
-  // appWideNotificationSchema,
-  // AppWideNotification,
-  // NormalizedAppWideNotification,
 } from "./appWideNotificationConstants";
 
 function* fetchAppWideNotifications() {
   const request = createRequest(
     createUrl("announcement/", {
-      outdoor_sports_map_usage: 1,
-      page_size: 1000,
+      outdoor_sports_map_usage: 1
     })
   );
 
   const { response, bodyAsJson } = yield call(callApi, request);
 
   if (response.status === 200) {
-    // const data = normalizeEntityResults<AppWideNotification, NormalizedAppWideNotification, number[]>(
-    //   bodyAsJson.results,
-    //   new schema.Array(appWideNotificationSchema)
-    // );
-
     yield put(receiveAppWideNotifications(bodyAsJson.results));
   } else {
     yield put(setFetchError(bodyAsJson.results));

--- a/src/domain/app/appWideNotification/saga.ts
+++ b/src/domain/app/appWideNotification/saga.ts
@@ -1,0 +1,48 @@
+import { schema } from "normalizr";
+import { all, call, fork, put, takeLatest } from "redux-saga/effects";
+
+import {
+  callApi,
+  createRequest,
+  createUrl,
+  normalizeEntityResults,
+} from "../../api/apiHelpers";
+import { receiveAppWideNotifications, setFetchError } from "./actions";
+import {
+  AppWideNotificationActions,
+  appWideNotificationSchema,
+  AppWideNotification,
+  NormalizedAppWideNotification,
+} from "./appWideNotificationConstants";
+
+function* fetchAppWideNotifications() {
+  const request = createRequest(
+    createUrl("announcement/", {
+      outdoor_sports_map_usage: 1,
+      page_size: 1000,
+    })
+  );
+
+  const { response, bodyAsJson } = yield call(callApi, request);
+
+  //console.log(bodyAsJson);
+
+  if (response.status === 200) {
+    const data = normalizeEntityResults<AppWideNotification, NormalizedAppWideNotification, number[]>(
+      bodyAsJson.results,
+      new schema.Array(appWideNotificationSchema)
+    );
+
+    yield put(receiveAppWideNotifications(data));
+  } else {
+    yield put(setFetchError(bodyAsJson.results));
+  }
+}
+
+function* watchFetchAppWideNotifications() {
+  yield takeLatest(AppWideNotificationActions.FETCH, fetchAppWideNotifications);
+}
+
+export default function* saga() {
+  yield all([fork(watchFetchAppWideNotifications)]);
+}

--- a/src/domain/app/appWideNotification/saga.ts
+++ b/src/domain/app/appWideNotification/saga.ts
@@ -1,19 +1,13 @@
 import { all, call, fork, put, takeLatest } from "redux-saga/effects";
 
-import {
-  callApi,
-  createRequest,
-  createUrl,
-} from "../../api/apiHelpers";
+import { callApi, createRequest, createUrl } from "../../api/apiHelpers";
 import { receiveAppWideNotifications, setFetchError } from "./actions";
-import {
-  AppWideNotificationActions,
-} from "./appWideNotificationConstants";
+import { AppWideNotificationActions } from "./appWideNotificationConstants";
 
 function* fetchAppWideNotifications() {
   const request = createRequest(
     createUrl("announcement/", {
-      outdoor_sports_map_usage: 1
+      outdoor_sports_map_usage: 1,
     })
   );
 

--- a/src/domain/app/appWideNotification/saga.ts
+++ b/src/domain/app/appWideNotification/saga.ts
@@ -10,9 +10,9 @@ import {
 import { receiveAppWideNotifications, setFetchError } from "./actions";
 import {
   AppWideNotificationActions,
-  appWideNotificationSchema,
-  AppWideNotification,
-  NormalizedAppWideNotification,
+  // appWideNotificationSchema,
+  // AppWideNotification,
+  // NormalizedAppWideNotification,
 } from "./appWideNotificationConstants";
 
 function* fetchAppWideNotifications() {
@@ -25,15 +25,13 @@ function* fetchAppWideNotifications() {
 
   const { response, bodyAsJson } = yield call(callApi, request);
 
-  //console.log(bodyAsJson);
-
   if (response.status === 200) {
-    const data = normalizeEntityResults<AppWideNotification, NormalizedAppWideNotification, number[]>(
-      bodyAsJson.results,
-      new schema.Array(appWideNotificationSchema)
-    );
+    // const data = normalizeEntityResults<AppWideNotification, NormalizedAppWideNotification, number[]>(
+    //   bodyAsJson.results,
+    //   new schema.Array(appWideNotificationSchema)
+    // );
 
-    yield put(receiveAppWideNotifications(data));
+    yield put(receiveAppWideNotifications(bodyAsJson.results));
   } else {
     yield put(setFetchError(bodyAsJson.results));
   }

--- a/src/domain/app/appWideNotification/selectors.ts
+++ b/src/domain/app/appWideNotification/selectors.ts
@@ -4,10 +4,12 @@ import type { AppState } from "../../../domain/app/appConstants";
 
 export const getData = (state: AppState) => state.appWideNotification.data;
 
-export const getAppWideNotificationsObject = (state: AppState) => state.appWideNotification;
+export const getAppWideNotificationsObject = (state: AppState) =>
+  state.appWideNotification;
 
 export const getIsFetchingAppWideNotification = (state: AppState) =>
   state.appWideNotification.isFetching;
 
 export const getIsLoading = (state: AppState) =>
-  state.appWideNotification.isFetching && isEmpty(state.appWideNotification.data);
+  state.appWideNotification.isFetching &&
+  isEmpty(state.appWideNotification.data);

--- a/src/domain/app/appWideNotification/selectors.ts
+++ b/src/domain/app/appWideNotification/selectors.ts
@@ -2,12 +2,7 @@ import isEmpty from "lodash/isEmpty";
 
 import type { AppState } from "../../../domain/app/appConstants";
 
-export const getAppWideNotificationById = (state: AppState, appWideNotificationId: string) =>
-  state.appWideNotification.byId[appWideNotificationId];
-
-export const getAll = (state: AppState) =>
-  /* , props: Object */
-  state.appWideNotification.all.map((appWideNotificationId) => getAppWideNotificationById(state, appWideNotificationId));
+export const getData = (state: AppState) => state.appWideNotification.data;
 
 export const getAppWideNotificationsObject = (state: AppState) => state.appWideNotification;
 
@@ -15,4 +10,4 @@ export const getIsFetchingAppWideNotification = (state: AppState) =>
   state.appWideNotification.isFetching;
 
 export const getIsLoading = (state: AppState) =>
-  state.appWideNotification.isFetching && isEmpty(state.appWideNotification.all);
+  state.appWideNotification.isFetching && isEmpty(state.appWideNotification.data);

--- a/src/domain/app/appWideNotification/selectors.ts
+++ b/src/domain/app/appWideNotification/selectors.ts
@@ -1,0 +1,18 @@
+import isEmpty from "lodash/isEmpty";
+
+import type { AppState } from "../../../domain/app/appConstants";
+
+export const getAppWideNotificationById = (state: AppState, appWideNotificationId: string) =>
+  state.appWideNotification.byId[appWideNotificationId];
+
+export const getAll = (state: AppState) =>
+  /* , props: Object */
+  state.appWideNotification.all.map((appWideNotificationId) => getAppWideNotificationById(state, appWideNotificationId));
+
+export const getAppWideNotificationsObject = (state: AppState) => state.appWideNotification;
+
+export const getIsFetchingAppWideNotification = (state: AppState) =>
+  state.appWideNotification.isFetching;
+
+export const getIsLoading = (state: AppState) =>
+  state.appWideNotification.isFetching && isEmpty(state.appWideNotification.all);

--- a/src/domain/bootstrap/createRootReducer.ts
+++ b/src/domain/bootstrap/createRootReducer.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from "redux";
 
+import appWideNotificationReducer from "../app/appWideNotification/reducer";
 import languageReducer from "../i18n/state/reducer";
 import mapReducer from "../map/state/reducer";
 import serviceReducer from "../service/reducer";
@@ -13,6 +14,7 @@ const createRootReducer = () =>
     map: mapReducer,
     search: searchReducer,
     service: serviceReducer,
+    appWideNotification: appWideNotificationReducer,
   });
 
 export default createRootReducer;

--- a/src/domain/bootstrap/rootSaga.ts
+++ b/src/domain/bootstrap/rootSaga.ts
@@ -1,5 +1,6 @@
 import { all, fork } from "redux-saga/effects";
 
+import appWideNotificationSaga from "../app/appWideNotification/saga";
 import appSaga from "../app/state/saga";
 import mapSaga from "../map/state/saga";
 import serviceSaga from "../service/saga";
@@ -13,5 +14,6 @@ export default function* rootSaga() {
     fork(searchSaga),
     fork(mapSaga),
     fork(serviceSaga),
+    fork(appWideNotificationSaga),
   ]);
 }


### PR DESCRIPTION
## Description

This PR will add support for dynamic app wide notifications, that are fetched from servicemap api `/announcement`-endpoint with extra GET-parameter `outdoor_sports_map_usage=1`. Previously env-variables were used for this purpose, so this feature will add system admin a possibility to dynamically set up announcements to outdoor sports map application.

Browser SessionStorage is used to store announcement id and when user closes the notification dialog, notifications with the same id are not shown after page reload, unless the browser SessionStorage is cleared.

Refs HULK-3

## How Has This Been Tested?

Manual testing with servicemap test API: https://palvelukartta-api-test.agw.arodevtest.hel.fi/v2/announcement/ and locally, since this feature is not yet in the servicemap api production.

## Manual Testing Instructions for Reviewers

Testing can be currently done via servicemap test API: https://palvelukartta-api-test.agw.arodevtest.hel.fi/v2/announcement/ 

## Screenshots
![outdoor sports map dynamic notification](https://user-images.githubusercontent.com/2784933/185916236-933c9bd0-2383-4cc8-9231-8b359cb7bcbb.png)


