### PR TITLE
Use explicit type parameter in freetext-search

### DIFF
--- a/src/domain/unit/state/search/actions.ts
+++ b/src/domain/unit/state/search/actions.ts
@@ -15,6 +15,7 @@ export const searchUnits = (
   const init = {
     input,
     service: `${values(UnitServices).join(",")}`,
+    type: "unit",
   };
 
   // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
## Description

Latest API-changes require explicit type-mapping in freetext-search, use it to overcome search-issues.

## Context

Freetext-search was not working, because some of the latest search-results in the new search engine do not have a separate `id`-field. This happens to for example addresses, where the object identity is generated by different means. Solve this issue by using a an explicit type `unit` in search, as we need to search only units.

Fixes: https://github.com/City-of-Helsinki/outdoors-sports-map/issues/175

## How Has This Been Tested?

Locally.

## Manual Testing Instructions for Reviewers

Can be tested locally.

## Screenshots

![outdoor-sports-map-fixed-search](https://user-images.githubusercontent.com/2784933/207612184-4426639c-bf22-4bce-a81c-b3d0cc3e3226.png)

