### PR TITLE
Automatic satisfactory/unknown observation status

### DIFF
--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -38,6 +38,7 @@
     "SHOW_LESS": "Show less",
     "STATUS": "Condition",
     "UNKNOWN": "Unknown",
+    "SATISFACTORY": "Decent",
     "UPDATED": "Updated",
     "MAINTENANCE_DONE": "Maintained",
     "FILTER": {

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -38,6 +38,7 @@
     "SHOW_LESS": "Näytä vähemmän",
     "STATUS": "Kunto",
     "UNKNOWN": "Tuntematon",
+    "SATISFACTORY": "Tyydyttävä",
     "UPDATED": "Päivitetty",
     "MAINTENANCE_DONE": "Kunnostettu",
     "FILTER": {

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -38,6 +38,7 @@
     "SHOW_LESS": "Visa mindre",
     "STATUS": "Skick",
     "UNKNOWN": "Okänt",
+    "SATISFACTORY": "Hyfsad",
     "UPDATED": "Uppdaterad",
     "MAINTENANCE_DONE": "Iståndsatt",
     "FILTER": {

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -26,7 +26,7 @@ import UnitObservationStatus, {
   StatusUpdatedAgo,
 } from "../UnitObservationStatus";
 import * as fromUnit from "../state/selectors";
-import { Unit, UnitConnectionTags } from "../unitConstants";
+import { Translatable, Unit, UnitConnectionTags } from "../unitConstants";
 import {
   createPalvelukarttaUrl,
   createReittiopasUrl,
@@ -307,7 +307,7 @@ function NoticeInfo({ unit }: NoticeInfoProps) {
     <BodyBox title={t("UNIT_BROWSER.NOTICE")}>
       <StatusUpdated time={getObservationTime(notice)} />
       <ReactMarkdown
-        children={getAttr(notice.value, language)}
+        children={getAttr(notice.value as Translatable<string>, language)}
         // Insert a break for each newline character
         // https://github.com/rexxars/react-markdown/issues/105#issuecomment-346103734
         remarkPlugins={[breaks]}

--- a/src/domain/unit/state/reducer.ts
+++ b/src/domain/unit/state/reducer.ts
@@ -9,7 +9,11 @@ import {
   SwimmingServices,
 } from "../../service/serviceConstants";
 import { QualityEnum, UnitActions } from "../unitConstants";
-import { enumerableQuality, getUnitQuality } from "../unitHelpers";
+import {
+  enumerableQuality,
+  getUnitQuality,
+  handleUnitConditionUpdates,
+} from "../unitHelpers";
 
 const isFetchingReducer = handleActions(
   {
@@ -37,7 +41,7 @@ const byIdReducer = handleActions(
     [UnitActions.RECEIVE]: (
       state: Record<string, any>,
       { payload: { entities } }: EntityAction
-    ) => entities.unit,
+    ) => handleUnitConditionUpdates(entities.unit),
   },
   {}
 );

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -45,7 +45,7 @@ export const SkiingFilters = [
 
 export type SkiingFilter = typeof SkiingFilters[number];
 
-type Translatable<T = string> = {
+export type Translatable<T = string> = {
   fi: T;
   sv: T;
   en: T;
@@ -91,7 +91,7 @@ export type Unit = {
     primary: boolean;
     quality: string;
     name: Translatable<string>;
-    value: Translatable<string>;
+    value: string | Translatable<string>;
     time: string;
   }>;
   www: Translatable<string>;

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -180,11 +180,34 @@ export const UnitQuality = {
   UNKNOWN: "unknown",
 };
 
+export const UnitQualityConst = {
+  GOOD: "good",
+  SATISFACTORY: "satisfactory",
+  UNUSABLE: "unusable",
+  UNKNOWN: "unknown",
+} as const;
+
 export const QualityEnum = {
   [UnitQuality.GOOD]: 1,
   [UnitQuality.SATISFACTORY]: 2,
   [UnitQuality.UNUSABLE]: 3,
   [UnitQuality.UNKNOWN]: 4,
+};
+
+// Number of days from the latest observation to automatically change condition
+export const UnitAutomaticConditionChangeDays = {
+  [UnitFilters.SKIING]: {
+    [UnitQualityConst.SATISFACTORY]: 7,
+    [UnitQualityConst.UNKNOWN]: 10,
+  },
+  [UnitFilters.SWIMMING]: {
+    [UnitQualityConst.SATISFACTORY]: undefined,
+    [UnitQualityConst.UNKNOWN]: 5,
+  },
+  [UnitFilters.ICE_SKATING]: {
+    [UnitQualityConst.SATISFACTORY]: undefined,
+    [UnitQualityConst.UNKNOWN]: 10,
+  },
 };
 
 export const UnitActions = {


### PR DESCRIPTION
## Description

Automatically change the latest primary observation to be either satisfactory or unknown. If a certain amount of days
has passed since the last observation, do the automatic change. Each sport has its own configuration for the number of days.

Current settings are:
* Swimming:
  * 5 days or more --> unknown
* Skiing:
  * 7 days or more --> satisfactory
  * 10 days or more --> unknown
* Ice skating:
  * 10 days or more --> unknown