### PR TITLE
Add water quality information to swimming places

### DIFF
--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -91,7 +91,9 @@
     "WATER_TEMPERATURE": "Water temperature",
     "WATER_TEMPERATURE_SENSOR": "Water temperature sensor",
     "CLOSE": "Close",
-    "SEE_ON_SERVICE_MAP": "More information on the Service Map"
+    "SEE_ON_SERVICE_MAP": "More information on the Service Map",
+    "WATER_QUALITY": "Water quality",
+    "WATER_QUALITY_SENSOR": "Water quality sensor"
 
   },
   "SEARCH": {
@@ -116,5 +118,11 @@
   },
   "JUMP_LINK": {
     "LABEL": "Jump straight to content"
+  },
+  "WATER_QUALITY": {
+    "normal": "Normal (hygienic water quality)",
+    "possibly_impaired": "Possibly impaired (hygienic water quality)",
+    "probably_impaired": "Possibly impaired (hygienic water quality)",
+    "error": "No estimate"
   }
 }

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -91,7 +91,9 @@
     "WATER_TEMPERATURE": "Veden lämpötila",
     "WATER_TEMPERATURE_SENSOR": "Uimarantasensori",
     "CLOSE": "Sulje",
-    "SEE_ON_SERVICE_MAP": "Lisää tietoa palvelukartalla"
+    "SEE_ON_SERVICE_MAP": "Lisää tietoa palvelukartalla",
+    "WATER_QUALITY": "Vedenlaatu",
+    "WATER_QUALITY_SENSOR": "Vedenlaatusensori"
   },
   "SEARCH": {
     "SEARCH": "Etsi",
@@ -115,5 +117,11 @@
   },
   "JUMP_LINK": {
     "LABEL": "Siirry suoraan sisältöön"
+  },
+  "WATER_QUALITY": {
+    "normal": "Tavanomainen (veden hygieeninen laatu)",
+    "possibly_impaired": "Mahdollisesti heikentynyt (veden hygieeninen laatu)",
+    "probably_impaired": "Mahdollisesti heikentynyt (veden hygieeninen laatu)",
+    "error": "Ei arviota"
   }
 }

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -91,7 +91,9 @@
     "WATER_TEMPERATURE": "Vattnets temperatur",
     "WATER_TEMPERATURE_SENSOR": "Vattentemperatur sensor",
     "CLOSE": "Stänga",
-    "SEE_ON_SERVICE_MAP": "Mer information på servicekartan"
+    "SEE_ON_SERVICE_MAP": "Mer information på servicekartan",
+    "WATER_QUALITY": "Vattenkvalitet",
+    "WATER_QUALITY_SENSOR": "Vattenkvalitetssensor"
   },
   "SEARCH": {
     "SEARCH": "Sök",
@@ -115,5 +117,11 @@
   },
   "JUMP_LINK": {
     "LABEL": "Gå direkt till innehållet"
+  },
+  "WATER_QUALITY": {
+    "normal": "Normal (hygienisk vattenkvalitet)",
+    "possibly_impaired": "Möjligen försämrad (hygienisk vattenkvalitet)",
+    "probably_impaired": "Möjligen försämrad (hygienisk vattenkvalitet)",
+    "error": "Inget estimat"
   }
 }

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -423,6 +423,27 @@ function LiveLocationTemperature({
   );
 }
 
+type LiveWaterQualityProps = {
+  observation: Record<string, any>;
+};
+
+function LiveWaterQuality({
+  observation,
+}: LiveWaterQualityProps) {
+  const { t } = useTranslation();
+  const waterQuality = get(observation, "value.fi");
+  const observationTime = getObservationTime(observation);
+  
+  return (
+    <BodyBox title={t("UNIT_BROWSER.WATER_QUALITY")}>
+      <StatusUpdatedAgo
+        time={observationTime}
+        sensorName={t("UNIT_BROWSER.WATER_QUALITY_SENSOR")}
+      />
+      <p className={`water-quality-${waterQuality}`}>{t(`WATER_QUALITY.${waterQuality}`)}</p>
+    </BodyBox>
+  );
+}
 type BodyBoxProps = {
   title: string;
   children: ReactNode;
@@ -445,6 +466,7 @@ type SingleUnitBodyProps = {
   routeUrl?: string;
   temperatureObservation: Record<string, any> | null | undefined;
   palvelukarttaUrl?: string;
+  liveWaterQualityObservation: Record<string, any> | null | undefined;
 };
 
 export function SingleUnitBody({
@@ -454,6 +476,7 @@ export function SingleUnitBody({
   routeUrl,
   temperatureObservation,
   palvelukarttaUrl,
+  liveWaterQualityObservation
 }: SingleUnitBodyProps) {
   const language = useLanguage();
 
@@ -476,6 +499,11 @@ export function SingleUnitBody({
       {liveTemperatureObservation && (
         <LiveLocationTemperature observation={liveTemperatureObservation} />
       )}
+      {
+        liveWaterQualityObservation && (
+          <LiveWaterQuality observation={liveWaterQualityObservation} />
+        )
+      }
       <LocationInfo unit={currentUnit} />
       {getOpeningHours(currentUnit, language) && (
         <LocationOpeningHours unit={currentUnit} />
@@ -538,6 +566,10 @@ function UnitDetails({ onCenterMapToUnit, isExpanded, toggleIsExpanded }: Props)
     unit && has(unit, "observations")
       ? getObservation(unit, "live_swimming_water_temperature")
       : null;
+  const liveWaterQualityObservation =
+    unit && has(unit, "observations")
+      ? getObservation(unit, "live_swimming_water_quality")
+      : null;
   const routeUrl = unit && createReittiopasUrl(unit, language);
   const palvelukarttaUrl = unit && createPalvelukarttaUrl(unit, language);
   const isOpen = !!unitId;
@@ -586,6 +618,7 @@ function UnitDetails({ onCenterMapToUnit, isExpanded, toggleIsExpanded }: Props)
           liveTemperatureObservation={liveTemperatureObservation}
           routeUrl={routeUrl}
           temperatureObservation={temperatureObservation}
+          liveWaterQualityObservation={liveWaterQualityObservation}
           palvelukarttaUrl={palvelukarttaUrl}
         />
       </Page>

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -26,6 +26,16 @@ const liveTemperatureDataObservation = {
   },
 };
 
+const liveWaterQualityObservation = {
+  unit: 40386,
+  id: 1406465,
+  property: "live_swimming_water_quality",
+  time: "2023-03-16T13:00:04.499827+0200",
+  expiration_time: null,
+  value: {
+      fi: "possibly_impaired"
+  }
+}
 const unit = {
   id: 40142,
   name: {
@@ -235,7 +245,7 @@ const unit = {
       ]
     }
   ],
-  observations: [temperatureDataObservation, liveTemperatureDataObservation],
+  observations: [temperatureDataObservation, liveTemperatureDataObservation, liveWaterQualityObservation],
   extra: {
     "lipas.routeLengthKm": 4,
     "lipas.litRouteLengthKm": 0,
@@ -347,6 +357,23 @@ describe("<UnitDetails />", () => {
 
         expect(wrapper.text().includes("kaksi tuntia sitten")).toEqual(true);
       });
+    });
+  });
+
+  describe("when live water quality data is available", () => {
+    const getWrapperWithLiveWaterQualityData = (props?: any, unit?: any) =>
+      getWrapper(props, unit);
+    const waterQuality= {
+      normal: "Tavanomainen (veden hygieeninen laatu)",
+      possibly_impaired: "Mahdollisesti heikentynyt (veden hygieeninen laatu)",
+      probably_impaired: "Mahdollisesti heikentynyt (veden hygieeninen laatu)",
+      error: "Ei arviota"
+    }
+    it("should be displayed", () => {
+      const wrapper = getWrapperWithLiveWaterQualityData();
+      const liveWaterQuality = waterQuality.possibly_impaired;
+
+      expect(wrapper.text().includes(liveWaterQuality)).toEqual(true);
     });
   });
 

--- a/src/domain/unit/details/_unitDetails.scss
+++ b/src/domain/unit/details/_unitDetails.scss
@@ -157,3 +157,17 @@
     }
   }
 }
+.water-quality{
+  &-normal {
+    background-color: #008450;
+  }
+  &-possibly_impaired {
+    background-color: #EFB700;
+  }
+  &-probably_impaired {
+    background-color: #EFB700;
+  }
+  &-error {
+    background-color: #a8b5c2;
+  }
+}


### PR DESCRIPTION
## Description

Add water quality information:
  - adds water quality information to the details of a swimming place whenever available

## Context

[HULK-22](https://project.anders.fi/browse/HULK-22)

## How Has This Been Tested?
Click to see the details of a swimming place check if water quality information is available and displayed (example swimming place with water quality info `Marjaniemi beach`)


## Manual Testing Instructions for Reviewers
Click to see the details of a swimming place check if water quality information is available and displayed (example swimming place with water quality info `Marjaniemi beach`)

## Screenshots
Water quality Info:

![normal-hygienic-water-quality](https://user-images.githubusercontent.com/117433931/225860095-b1510a81-4b38-4181-b037-242ead11800d.png)




