### PR TITLE
Add parking information

### DIFF
--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -68,7 +68,8 @@
     "HEATING": "Heating",
     "LIGHTED": "Lighting",
     "DRESSING_ROOM": "Dressing room",
-    "DOG_SKIJORING_TRACK": "Dog skijoring track"
+    "DOG_SKIJORING_TRACK": "Dog skijoring track",
+    "PARKING": "Parking"
   },
   "UNIT_BROWSER": {
     "LOADING": "Loading the object",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -68,7 +68,8 @@
     "HEATING": "Lämmitys",
     "LIGHTED": "Valaistus",
     "DRESSING_ROOM": "Pukukoppi",
-    "DOG_SKIJORING_TRACK": "Koirahiihtolatu"
+    "DOG_SKIJORING_TRACK": "Koirahiihtolatu",
+    "PARKING": "Pysäköinti"
   },
   "UNIT_BROWSER": {
     "LOADING": "Ladataan kohdetta...",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -68,7 +68,8 @@
     "HEATING": "Uppvärmning",
     "LIGHTED": "Upplysning",
     "DRESSING_ROOM": "Omklädningsrum",
-    "DOG_SKIJORING_TRACK": "Hundskidspår"
+    "DOG_SKIJORING_TRACK": "Hundskidspår",
+    "PARKING": "Parkering"
   },
   "UNIT_BROWSER": {
     "LOADING": "Laddar objekt",

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -197,7 +197,10 @@ function LocationInfo({ unit }: LocationInfoProps) {
     unit,
     UnitConnectionTags.DOG_SKIJORING_TRACK
   )
-
+  const unitParkingConnection = getConnectionByTag(
+    unit,
+    UnitConnectionTags.PARKING
+  )
   // Should show info if at least some data is present
   if (
     !(
@@ -270,6 +273,12 @@ function LocationInfo({ unit }: LocationInfoProps) {
         <p className="no-margin">
           {`${t("UNIT_DETAILS.DRESSING_ROOM")}`}:{" "}
           {getAttr(unitDressingRoomConnection.name, language)}
+        </p>
+      )}
+      {unitParkingConnection !== undefined && (
+        <p className="no-margin">
+          {`${t("UNIT_DETAILS.PARKING")}`}:{" "}
+          {getAttr(unitParkingConnection.name, language)}
         </p>
       )}
       {unit.phone && (

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -183,6 +183,21 @@ const unit = {
       ]
     },
     {
+      section_type: "OTHER_INFO",
+      name: {
+          "fi": "Pysäköintipaikkoja 20 kpl, 2h pysäköinti.",
+          "sv": "20 parkeringsplatser, 2 timmars parkering.",
+          "en": "20 parking spaces, 2-hour parking."
+      },
+      www: null,
+      email: null,
+      phone: null,
+      contact_person: null,
+      tags: [
+          "#pysäköinti"
+      ]
+    },
+    {
       id: 12514,
       section_type: "OTHER_INFO",
       name: {
@@ -390,6 +405,22 @@ describe("<UnitDetails />", () => {
         connections: unit.connections.filter((con) => con.tags === undefined)
       });
       expect(wrapper.text().includes("Valvonta: Valvottu")).toEqual(false);
+    });
+  })
+
+  describe("when parking data is available", () => {
+    it("should be displayed", () => {
+      const wrapper = getWrapper();
+      expect(wrapper.text().includes("Pysäköinti: Pysäköintipaikkoja 20 kpl, 2h pysäköinti.")).toEqual(true);
+    });
+  });
+
+  describe("when parking data is not available", () => {
+    it("should not be displayed", () => {
+      const wrapper = getWrapper({}, {
+        connections: unit.connections.filter((con) => con.tags === undefined)
+      });
+      expect(wrapper.text().includes("Pysäköinti: Pysäköintipaikkoja 20 kpl, 2h pysäköinti.")).toEqual(false);
     });
   })
 

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -59,6 +59,7 @@ export const UnitConnectionTags = {
   LIGHTED: "#valaisu",
   DRESSING_ROOM: "#pukukoppi",
   DOG_SKIJORING_TRACK: "#koiralatu",
+  PARKING: "#pysäköinti",
 } as const;
 
 export type UnitConnection = {


### PR DESCRIPTION
## Description

Add parking information:
  - adds parking information when there exists #pysäköinti tag in the connections

## Context

[HULK-21](https://project.anders.fi/browse/HULK-21)

## How Has This Been Tested?

Click to see the details of an outdoor sport and see if `Parking` information is available under `Information`.

## Manual Testing Instructions for Reviewers

Click to see the details of an outdoor sport and see if `Parking` information is available under `Information`.

## Screenshots

