### PR TITLE
Feature/hulk 22 add water quality informations to swimming place

### DIFF
--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -92,7 +92,7 @@
     "WATER_TEMPERATURE_SENSOR": "Water temperature sensor",
     "CLOSE": "Close",
     "SEE_ON_SERVICE_MAP": "More information on the Service Map",
-    "WATER_QUALITY": "Water quality",
+    "WATER_QUALITY": "Hygienic water quality",
     "WATER_QUALITY_SENSOR": "Water quality sensor"
 
   },
@@ -120,9 +120,9 @@
     "LABEL": "Jump straight to content"
   },
   "WATER_QUALITY": {
-    "normal": "Normal (hygienic water quality)",
-    "possibly_impaired": "Possibly impaired (hygienic water quality)",
-    "probably_impaired": "Possibly impaired (hygienic water quality)",
+    "normal": "Normal",
+    "possibly_impaired": "Possibly impaired",
+    "probably_impaired": "Possibly impaired",
     "error": "No estimate"
   }
 }

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -92,7 +92,7 @@
     "WATER_TEMPERATURE_SENSOR": "Uimarantasensori",
     "CLOSE": "Sulje",
     "SEE_ON_SERVICE_MAP": "Lisää tietoa palvelukartalla",
-    "WATER_QUALITY": "Vedenlaatu",
+    "WATER_QUALITY": "Veden hygieeninen laatu",
     "WATER_QUALITY_SENSOR": "Vedenlaatusensori"
   },
   "SEARCH": {
@@ -119,9 +119,9 @@
     "LABEL": "Siirry suoraan sisältöön"
   },
   "WATER_QUALITY": {
-    "normal": "Tavanomainen (veden hygieeninen laatu)",
-    "possibly_impaired": "Mahdollisesti heikentynyt (veden hygieeninen laatu)",
-    "probably_impaired": "Mahdollisesti heikentynyt (veden hygieeninen laatu)",
+    "normal": "Tavanomainen",
+    "possibly_impaired": "Mahdollisesti heikentynyt",
+    "probably_impaired": "Mahdollisesti heikentynyt",
     "error": "Ei arviota"
   }
 }

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -92,7 +92,7 @@
     "WATER_TEMPERATURE_SENSOR": "Vattentemperatur sensor",
     "CLOSE": "Stänga",
     "SEE_ON_SERVICE_MAP": "Mer information på servicekartan",
-    "WATER_QUALITY": "Vattenkvalitet",
+    "WATER_QUALITY": "Hygienisk vattenkvalitet",
     "WATER_QUALITY_SENSOR": "Vattenkvalitetssensor"
   },
   "SEARCH": {
@@ -119,9 +119,9 @@
     "LABEL": "Gå direkt till innehållet"
   },
   "WATER_QUALITY": {
-    "normal": "Normal (hygienisk vattenkvalitet)",
-    "possibly_impaired": "Möjligen försämrad (hygienisk vattenkvalitet)",
-    "probably_impaired": "Möjligen försämrad (hygienisk vattenkvalitet)",
+    "normal": "Normal",
+    "possibly_impaired": "Möjligen försämrad",
+    "probably_impaired": "Möjligen försämrad",
     "error": "Inget estimat"
   }
 }

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -438,7 +438,7 @@ function LiveWaterQuality({
     <BodyBox title={t("UNIT_BROWSER.WATER_QUALITY")}>
       <StatusUpdatedAgo
         time={observationTime}
-        sensorName={t("UNIT_BROWSER.WATER_QUALITY_SENSOR")}
+        sensorName={""}
       />
       <p className={`water-quality-${waterQuality}`}>{t(`WATER_QUALITY.${waterQuality}`)}</p>
     </BodyBox>

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -364,9 +364,9 @@ describe("<UnitDetails />", () => {
     const getWrapperWithLiveWaterQualityData = (props?: any, unit?: any) =>
       getWrapper(props, unit);
     const waterQuality= {
-      normal: "Tavanomainen (veden hygieeninen laatu)",
-      possibly_impaired: "Mahdollisesti heikentynyt (veden hygieeninen laatu)",
-      probably_impaired: "Mahdollisesti heikentynyt (veden hygieeninen laatu)",
+      normal: "Tavanomainen",
+      possibly_impaired: "Mahdollisesti heikentynyt",
+      probably_impaired: "Mahdollisesti heikentynyt",
       error: "Ei arviota"
     }
     it("should be displayed", () => {


### PR DESCRIPTION
## Description
Edit label and title:
 - edits water quality title and labels

## Context

[HULK-22](https://project.anders.fi/browse/HULK-22)

## How Has This Been Tested?
Click to see the details of a swimming place check if water quality information is available and displayed (example swimming place with water quality info Marjaniemi beach)

## Manual Testing Instructions for Reviewers

Click to see the details of a swimming place check if water quality information is available and displayed (example swimming place with water quality info Marjaniemi beach)

## Screenshots

![water_quality](https://user-images.githubusercontent.com/117433931/226329653-a200d57c-05e5-420a-bfae-2863525fba9d.png)

