### PR TITLE
Display only season sports

### DIFF
--- a/src/domain/service/saga.ts
+++ b/src/domain/service/saga.ts
@@ -1,4 +1,3 @@
-import values from "lodash/values";
 import { schema } from "normalizr";
 import { all, call, fork, put, takeLatest } from "redux-saga/effects";
 
@@ -11,16 +10,16 @@ import {
 import { receiveServices, setFetchError } from "./actions";
 import {
   ServiceActions,
-  UnitServices,
   serviceSchema,
   Service,
   NormalizedService,
 } from "./serviceConstants";
+import { getOnSeasonServices } from "./serviceHelpers";
 
 function* fetchServices() {
   const request = createRequest(
     createUrl("service/", {
-      id: values(UnitServices),
+      id: getOnSeasonServices(),
       only: "id,name",
       page_size: 1000,
     })

--- a/src/domain/service/serviceHelpers.ts
+++ b/src/domain/service/serviceHelpers.ts
@@ -1,6 +1,8 @@
 import isEmpty from "lodash/isEmpty";
 
 import { DEFAULT_LANG } from "../app/appConstants";
+import { getToday, isOnSeason } from "../unit/seasons";
+import { SeasonDelimiter, Seasons } from "../unit/unitConstants";
 import { getAttr } from "../unit/unitHelpers";
 
 const getServiceName = (
@@ -22,6 +24,14 @@ const getServiceName = (
   }
 
   return "";
+};
+
+export const getOnSeasonServices = (
+  date: SeasonDelimiter = getToday()
+): Number[] => {
+  return Seasons.filter((season) => isOnSeason(date, season))
+    .map(({ services }) => services)
+    .reduce((flattened, services) => [...flattened, ...services], []);
 };
 
 export default getServiceName;

--- a/src/domain/unit/browser/UnitBrowser.tsx
+++ b/src/domain/unit/browser/UnitBrowser.tsx
@@ -13,7 +13,6 @@ import useAppSearch from "../../app/useAppSearch";
 import * as fromMap from "../../map/state/selectors";
 import { StatusFilters, UnitFilters } from "../unitConstants";
 import {
-  getOffSeasonSportFilters,
   getOnSeasonSportFilters,
   getSportSpecificationFilters,
 } from "../unitHelpers";
@@ -53,7 +52,6 @@ function UnitBrowser({ onViewChange, leafletMap }: Props) {
                 name: "sport",
                 active: sport,
                 options: getOnSeasonSportFilters(),
-                secondaryOptions: getOffSeasonSportFilters(),
               },
               {
                 name: "status",

--- a/src/domain/unit/state/actions.ts
+++ b/src/domain/unit/state/actions.ts
@@ -1,9 +1,8 @@
-import values from "lodash/values";
 import { createAction } from "redux-actions";
 
 import { ApiResponse } from "../../api/apiConstants";
 import { Action } from "../../app/appConstants";
-import { UnitServices } from "../../service/serviceConstants";
+import { getOnSeasonServices } from "../../service/serviceHelpers";
 import { NormalizedUnitSchema, UnitActions } from "../unitConstants";
 
 export const fetchUnits = (params: Record<string, any>): Action =>
@@ -27,7 +26,7 @@ export const searchUnits = (
 ): Action => {
   const init = {
     input,
-    service: `${values(UnitServices).join(",")}`,
+    service: `${getOnSeasonServices().join(",")}`,
   };
 
   // eslint-disable-next-line no-param-reassign
@@ -42,7 +41,7 @@ export const fetchSearchSuggestions = (input: string): Action =>
   createAction(UnitActions.FETCH_SEARCH_SUGGESTIONS)({
     params: {
       input,
-      service: `${values(UnitServices).join(",")}`,
+      service: `${getOnSeasonServices().join(",")}`,
       page_size: 5,
     },
   });

--- a/src/domain/unit/state/search/actions.ts
+++ b/src/domain/unit/state/search/actions.ts
@@ -1,8 +1,7 @@
-import values from "lodash/values";
 import { createAction } from "redux-actions";
 
 import { Action } from "../../../app/appConstants";
-import { UnitServices } from "../../../service/serviceConstants";
+import { getOnSeasonServices } from "../../../service/serviceHelpers";
 import { NormalizedUnitSchema } from "../../../unit/unitConstants";
 import { MAX_SUGGESTION_COUNT, UnitSearchActions } from "../../unitConstants";
 
@@ -14,7 +13,7 @@ export const searchUnits = (
 ): Action => {
   const init = {
     input,
-    service: `${values(UnitServices).join(",")}`,
+    service: `${getOnSeasonServices().join(",")}`,
     type: "unit",
   };
 
@@ -33,7 +32,7 @@ export const fetchUnitSuggestions = (input: string): Action =>
   createAction(UnitSearchActions.FETCH_UNIT_SUGGESTIONS)({
     params: {
       input,
-      service: `${values(UnitServices).join(",")}`,
+      service: `${getOnSeasonServices().join(",")}`,
       page_size: MAX_SUGGESTION_COUNT,
       type: "unit",
     },

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -1,6 +1,12 @@
 import { Geometry } from "geojson";
 import { NormalizedSchema, schema } from "normalizr";
 
+import {
+  IceSkatingServices,
+  SkiingServices,
+  SwimmingServices,
+  IceSwimmingServices,
+} from "../service/serviceConstants";
 import { normalizeActionName } from "../utils";
 
 export const UNIT_PIN_HEIGHT = 40;
@@ -121,6 +127,7 @@ export type Season = {
   start: SeasonDelimiter;
   end: SeasonDelimiter;
   filters: SportFilter[];
+  services: Number[];
 };
 
 export const SummerSeason: Season = {
@@ -133,6 +140,7 @@ export const SummerSeason: Season = {
     month: 9,
   },
   filters: [UnitFilters.SWIMMING],
+  services: [...SwimmingServices],
 };
 
 export const WinterSeason: Season = {
@@ -149,6 +157,7 @@ export const WinterSeason: Season = {
     UnitFilters.ICE_SKATING,
     UnitFilters.ICE_SWIMMING,
   ],
+  services: [...IceSkatingServices, ...IceSwimmingServices, ...SkiingServices],
 };
 
 export const YearRoundSeason: Season = {
@@ -161,6 +170,7 @@ export const YearRoundSeason: Season = {
     month: 11,
   },
   filters: [],
+  services: [],
 };
 
 export const Seasons: Array<Season> = [

--- a/src/domain/unit/unitHelpers.ts
+++ b/src/domain/unit/unitHelpers.ts
@@ -21,6 +21,7 @@ import {
   UnitServices,
   IceSwimmingServices,
 } from "../service/serviceConstants";
+import { getOnSeasonServices } from "../service/serviceHelpers";
 import { getToday, isOnSeason } from "./seasons";
 import {
   DEFAULT_STATUS_FILTER,
@@ -46,7 +47,7 @@ import {
 export const getFetchUnitsRequest = (params: Record<string, any>) =>
   createRequest(
     createUrl("unit/", {
-      service: getAllSportServices(),
+      service: getOnSeasonServices().join(","),
       only: "id,name,location,street_address,address_zip,extensions,services,municipality,phone,www,description,picture_url,extra",
       include: "observations,connections",
       geometry: "true",


### PR DESCRIPTION
## Description

Display only season sports:
 - displays only on season sports as options for Choosing sport
 - Search suggestions should only contains on season sports
 - initial request to load data should only contains on season service ids

## Context

[HULK-29](https://project.anders.fi/browse/HULK-29)

## How Has This Been Tested?

See if only season sports are displayed as option for choosing sport  `Summer : Swimming  /  Winter : Skiing, Skating, Ice swimming`


## Manual Testing Instructions for Reviewers

See if only season sports are displayed as option for choosing sport  `Summer : Swimming  /  Winter : Skiing, Skating, Ice swimming`

## Screenshots

Season sport options:

![winter_sports](https://user-images.githubusercontent.com/117433931/226609788-5ee73f3a-a37b-4cf3-803c-721bfb5920d2.png)

Season search suggestions:

![search_should_show_only_season_sport_suggestions](https://user-images.githubusercontent.com/117433931/226837752-92ef1870-936e-44af-9912-994ac70c2844.png)

Season request service ids(loading data):

![requests_should_only_contain_season_sport_service_ids](https://user-images.githubusercontent.com/117433931/226837836-1ddce5f5-89e0-4805-92cc-5d94ead0c36d.png)


