### PR TITLE
Zoom to unit when it is selected

### DIFF
--- a/src/domain/map/MapView.tsx
+++ b/src/domain/map/MapView.tsx
@@ -89,6 +89,7 @@ class MapView extends Component<Props, State> {
   };
 
   setView = (coordinates: [number, number]) => {
+    console.log('coordinates from MapView setView are ====>', coordinates)
     this.leafletElement?.setView(coordinates);
   };
 
@@ -106,7 +107,7 @@ class MapView extends Component<Props, State> {
     } = this.props;
 
     const { zoomLevel } = this.state;
-
+    console.log('selectedUnit from MapView is ====>', selectedUnit)
     return (
       <View
         id="map-view"

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -108,7 +108,7 @@ export type Unit = {
   };
   phone?: string;
   url?: string;
-  geometry: Geometry;
+  geometry: Geometry & { coordinates: Array<Array<number>> };
   location: {
     coordinates: [number, number];
   };


### PR DESCRIPTION
## Description

Zoom to unit when it is selected:
  - drops the pin to the selected unit when a unit is selected from search suggestions.
## Context

[HULK-28](https://project.anders.fi/browse/HULK-28)

## How Has This Been Tested?
- put an address in the search bar
- click on an address from suggested address
- you should see the map pin indicating the selected unit.

## Manual Testing Instructions for Reviewers

- put an address in the search bar
- click on an address from suggested address
- you should see the map pin indicating the selected unit.

## Screenshots

![pin_to_selected_unit](https://user-images.githubusercontent.com/117433931/229108507-e0c2cad9-962a-42c6-ab62-d4bae157b2a5.gif)

