### PR TITLE
Zoom to unit when it is selected

### DIFF
--- a/src/domain/home/HomeContainer.tsx
+++ b/src/domain/home/HomeContainer.tsx
@@ -9,6 +9,7 @@ import AppInfoDropdown from "../app/AppInfoDropdown";
 import routerPaths from "../app/appRoutes";
 import useIsUnitBrowserSearchView from "../app/useIsUnitBrowserSearchView";
 import Map from "../map/Map";
+import { DETAIL_ZOOM_IN } from "../map/mapConstants";
 import UnitBrowser from "../unit/browser/UnitBrowser";
 import UnitDetails from "../unit/details/UnitDetails";
 import { getUnitPosition } from "../unit/unitHelpers";
@@ -92,6 +93,23 @@ function HomeContainer() {
 
         if (adjustedCenter) {
           leafletElement?.setView(adjustedCenter);
+          //if the geometry is a MultiLineString, then zoom in to the bounds of the geometry
+          if(unit.geometry.type === 'MultiLineString') {
+            //get a flat array of coordinates
+            const coordinates = unit.geometry.coordinates.flat();
+            //get the maximum latitude and longitude
+            const maxLat = Math.max(...coordinates.map((coord:number[]) => coord[0])),
+            minLat = Math.min(...coordinates.map((coord:number[]) => coord[0])),
+            maxLng = Math.max(...coordinates.map((coord:number[]) => coord[1])),
+            minLng = Math.min(...coordinates.map((coord:number[]) => coord[1]));
+            //set the zoom and fit the bounds of the coordinates
+            leafletElement?.setZoom(DETAIL_ZOOM_IN);
+            leafletElement?.fitBounds([[minLat, minLng], [maxLat, maxLng]]);
+            //if the geometry is a point, then zoom in to that point
+          }else{
+            const coordinates = unit.location.coordinates;
+            leafletElement?.flyTo([coordinates[1], coordinates[0]], DETAIL_ZOOM_IN);
+          }
         }
       } else {
         // On mobile we want to move the map 250px down from the center, so the

--- a/src/domain/map/mapConstants.ts
+++ b/src/domain/map/mapConstants.ts
@@ -22,6 +22,8 @@ export const MIN_ZOOM = 11;
 
 export const MAX_ZOOM = 18;
 
+export const DETAIL_ZOOM_IN = 14;
+
 export const BOUNDARIES: LatLngBoundsLiteral = [
   [59.4, 23.8],
   [61.5, 25.8],


### PR DESCRIPTION
## Description

Zoom in to selected Unit:
 - when a search suggestion is selected, it zooms in to the selected unit.
 - when a unit on the map is clicked, it should show the selected unit zoomed in.

## Context

[HULK-2](https://andersinno.atlassian.net/browse/HULK-2)

## How Has This Been Tested?

- search for a unit
- click on selected unit
- expect to see that selected unit zoomed in the map

## Manual Testing Instructions for Reviewers

- search for a unit
- click on selected unit
- expect to see that selected unit zoomed in the map

## Screenshots

![zoom_in_to_selected_unit](https://user-images.githubusercontent.com/117433931/229734189-9db8b401-a953-4281-a705-98c171bace47.gif)

