### PR TITLE
Remove information points for now

### DIFF
--- a/src/domain/service/serviceConstants.ts
+++ b/src/domain/service/serviceConstants.ts
@@ -44,7 +44,6 @@ export const IceSwimmingServices = [UnitServices.ICE_SWIMMING_PLACE];
 
 export const SupportingServices = [
   UnitServices.LEAN_TO,
-  UnitServices.INFORMATION_POINT,
   UnitServices.COOKING_FACILITY,
   UnitServices.CAMPING,
   UnitServices.SKI_LODGE,
@@ -57,7 +56,6 @@ export const SummerSupportingServices = [
 
 export const YearRoundSupportingServices = [
   UnitServices.COOKING_FACILITY,
-  UnitServices.INFORMATION_POINT,
   UnitServices.SKI_LODGE,
 ];
 

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -194,11 +194,7 @@ export const YearRoundSeason: Season = {
   },
   filters: [],
   services: [...YearRoundSupportingServices],
-  hikeFilters: [
-    UnitFilters.COOKING_FACILITY,
-    UnitFilters.INFORMATION_POINT,
-    UnitFilters.SKI_LODGE,
-  ],
+  hikeFilters: [UnitFilters.COOKING_FACILITY, UnitFilters.SKI_LODGE],
 };
 
 export const Seasons: Array<Season> = [


### PR DESCRIPTION
## Description

Remove information points for now.

## Context

Some information points (that originate from LIPAS-source system) are not suitable for this service, thus we will not include any information point for now (until there is some other way to get correct units from the source).

[HUL-7](https://andersinno.atlassian.net/browse/HUL-7)

## How Has This Been Tested?

Locally.

## Screenshots

![Outdoor Exercise Map 2023-04-11 16-11-57](https://user-images.githubusercontent.com/2784933/231173433-334525df-e99b-44d6-81e1-744c6c86e63c.png)

