### PR TITLE
Add HDS CookieConsent modal

### DIFF
--- a/src/domain/app/App.tsx
+++ b/src/domain/app/App.tsx
@@ -1,6 +1,7 @@
 import { Redirect, Route, Switch, RouteComponentProps } from "react-router-dom";
 
 import LanguageAwareRoutes from "./AppLanguageAwareRoutes";
+import CookieConsent from "./CookieConsent";
 import AppWideNotification from "./appWideNotification/AppWideNotification";
 import JumpLink from "../../common/a11y/JumpLink";
 import ResetFocus from "../../common/a11y/ResetFocus";
@@ -22,6 +23,7 @@ function App() {
       <ResetFocus />
       <JumpLink />
       <AppWideNotification />
+      <CookieConsent />
       <Switch>
         <Route path={`/${languageParam}`} component={LanguageAwareRoutes} />
         <Route

--- a/src/domain/app/CookieConsent.tsx
+++ b/src/domain/app/CookieConsent.tsx
@@ -1,0 +1,34 @@
+import { CookieModal, ContentSource } from 'hds-react';
+import React from 'react';
+import { useTranslation } from "react-i18next";
+
+function CookieConsent() {
+  const { t, i18n } = useTranslation();
+
+  const contentSource: ContentSource = {
+    siteName: t("APP.NAME"),
+    currentLanguage:  i18n.language as 'fi' | 'sv' | 'en',
+    optionalCookies: {
+      cookies: [
+        {
+          commonGroup: 'statistics',
+          commonCookie: 'matomo',
+        },
+      ],
+    },
+    focusTargetSelector: '#main-content',
+    onAllConsentsGiven: function (consents) {
+      if (!consents.matomo) {
+        // stop matomo tracking
+      }
+    },
+  };
+
+  return (
+    <>
+      <CookieModal contentSource={contentSource} />
+    </>
+  );
+}
+
+export default CookieConsent;

--- a/src/global.scss
+++ b/src/global.scss
@@ -37,3 +37,8 @@ body {
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
 }
+
+#HdsCookieConsentContainer {
+  position: relative;
+  z-index: 100001;
+}


### PR DESCRIPTION
## Description

Add Helsinki Design System CookieConsent modal to the page.

## Context

Refs [HUL-12](https://andersinno.atlassian.net/browse/HUL-12)

## How Has This Been Tested?

Tested in local development environment.

## Screenshots
Example of the whole modal:
<img width="1545" alt="fi" src="https://github.com/City-of-Helsinki/outdoors-sports-map/assets/10584178/5a7dc828-db48-4968-bffd-254269af9e49">

Also support for English and Swedish:
<img width="1245" alt="en" src="https://github.com/City-of-Helsinki/outdoors-sports-map/assets/10584178/a7b831d7-3d82-490d-9de7-add2c60930f5">

