### PR TITLE
Fix CookieConsent language change

### DIFF
--- a/src/domain/app/CookieConsent.tsx
+++ b/src/domain/app/CookieConsent.tsx
@@ -22,6 +22,9 @@ function CookieConsent() {
         },
       ],
     },
+    language: {
+      onLanguageChange: (code: string) => i18n.changeLanguage(code),
+    },
     focusTargetSelector: '#main-content',
     onAllConsentsGiven: function (consents) {
       if (consents.matomo) {


### PR DESCRIPTION
The language change worked only if the whole site language was changed. Fix it so that the language change works also when changed from the cookie modal.
