### PR TITLE
Add Matomo cookie details

### DIFF
--- a/src/domain/app/CookieConsent.tsx
+++ b/src/domain/app/CookieConsent.tsx
@@ -15,12 +15,20 @@ function CookieConsent() {
     siteName: t("APP.NAME"),
     currentLanguage:  i18n.language as 'fi' | 'sv' | 'en',
     optionalCookies: {
-      cookies: [
+      groups: [
         {
           commonGroup: 'statistics',
-          commonCookie: 'matomo',
-        },
-      ],
+          cookies: [
+            {
+              id: 'matomo',
+              name: '_pk*',
+              hostName: 'digia.fi',
+              description: t('COOKIES.MATOMO'),
+              expiration: t('COOKIES.EXPIRATION_DAYS', { days: 393 })
+            }
+          ]
+        }
+      ]
     },
     language: {
       onLanguageChange: (code: string) => i18n.changeLanguage(code),

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -137,5 +137,9 @@
     "possibly_impaired": "Possibly impaired",
     "probably_impaired": "Possibly impaired",
     "error": "No estimate"
+  },
+  "COOKIES": {
+    "MATOMO": "A cookie of the Matomo statistics system",
+    "EXPIRATION_DAYS": "{{ days }} days"
   }
 }

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -136,5 +136,9 @@
     "possibly_impaired": "Mahdollisesti heikentynyt",
     "probably_impaired": "Mahdollisesti heikentynyt",
     "error": "Ei arviota"
+  },
+  "COOKIES": {
+    "MATOMO": "Matomo-tilastointijärjestelmän eväste",
+    "EXPIRATION_DAYS": "{{ days }} päivää"
   }
 }

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -136,5 +136,9 @@
     "possibly_impaired": "Möjligen försämrad",
     "probably_impaired": "Möjligen försämrad",
     "error": "Inget estimat"
+  },
+  "COOKIES": {
+    "MATOMO": "Kaka för statistiksystemet Matomo",
+    "EXPIRATION_DAYS": "{{ days }} dagar"
   }
 }


### PR DESCRIPTION
## Description

Add details about Matomo to cookie consent modal.


## Screenshots

![matomo](https://github.com/City-of-Helsinki/outdoors-sports-map/assets/10584178/8fa8a07c-1fe7-4639-8992-551cbb2a1b91)
