### PR TITLE
Add possibility to hide/show home-container

### DIFF
--- a/src/domain/app/AppHeader.tsx
+++ b/src/domain/app/AppHeader.tsx
@@ -1,3 +1,4 @@
+import { IconAngleDown } from "hds-react";
 import { useTranslation } from "react-i18next";
 import { Link as RRLink, useLocation } from "react-router-dom";
 
@@ -18,7 +19,12 @@ const countryFlags: {
   en: FlagUnitedKingdom24pxFlat,
 };
 
-function ApplicationHeader() {
+type ApplicationHeaderProps = {
+  toggleExpand: () => void;
+  isExpanded: boolean;
+};
+
+function ApplicationHeader({toggleExpand, isExpanded}: ApplicationHeaderProps) {
   const { t } = useTranslation();
   const currentLanguage = useLanguage();
 
@@ -48,6 +54,7 @@ function ApplicationHeader() {
               />
             </RRLink>
           ))}
+          <IconAngleDown onClick={toggleExpand} className={ isExpanded ? "home-container-icon-expanded" : "home-container-icon"} />
       </div>
     </header>
   );

--- a/src/domain/home/HomeContainer.tsx
+++ b/src/domain/home/HomeContainer.tsx
@@ -28,9 +28,11 @@ function useIsUnitDetailsSearchView() {
 type MapLayoutProps = {
   content: ReactNode;
   map: ReactNode;
+  isExpanded: boolean;
+  toggleIsExpanded: () => void;
 };
 
-function MapLayout({ content, map }: MapLayoutProps) {
+function MapLayout({ content, map, isExpanded, toggleIsExpanded }: MapLayoutProps) {
   const isUnitSearchOpen = useIsUnitBrowserSearchView();
   const isUnitDetailsOpen = useIsUnitDetailsSearchView();
 
@@ -45,8 +47,8 @@ function MapLayout({ content, map }: MapLayoutProps) {
           "fill-color-background": isUnitSearchOpen,
         })}
       >
-        <ApplicationHeader />
-        <div className="map-foreground-content">{content}</div>
+        <ApplicationHeader toggleExpand={toggleIsExpanded} isExpanded={isExpanded} />
+        <div className={ isExpanded ? "map-foreground-content" : "map-foreground-content hidden"}>{content}</div>
       </div>
       <AppInfoDropdown />
       <div className="map-container">{map}</div>
@@ -58,10 +60,16 @@ function HomeContainer() {
   const mapRef = useRef<RLMap | null>(null);
   const leafletElementRef = useRef<L.Map | null>(null);
   const isMobile = useIsMobile();
-  const [isUnitDetailsExpanded, setIsUnitDetailsExpanded] = useState(false)
+  const [isUnitDetailsExpanded, setIsUnitDetailsExpanded] = useState(false);
 
   const toggleIsUnitDetailsExpanded = () => {
     setIsUnitDetailsExpanded(!isUnitDetailsExpanded)
+  }
+
+  const [isHomeContainerExpanded, setIsHomeContainerExpanded] = useState(true);
+
+  const toggleIsHomeContainerExpanded = () => {
+    setIsHomeContainerExpanded(!isHomeContainerExpanded)
   }
 
   const handleOnViewChange = useCallback((coordinates) => {
@@ -164,6 +172,8 @@ function HomeContainer() {
             onCenterMapToUnit={handleCenterMapToUnit}
           />
         }
+        isExpanded={isHomeContainerExpanded}
+        toggleIsExpanded={toggleIsHomeContainerExpanded}
       />
       <CookieConsent />
     </>

--- a/src/domain/home/_home.scss
+++ b/src/domain/home/_home.scss
@@ -53,6 +53,10 @@
     & > * {
       pointer-events: initial;
     }
+
+    &.hidden {
+      display: none;
+    }
   }
 
   &-unit-browser {
@@ -65,6 +69,26 @@
 
     &.hidden {
       display: none;
+    }
+  }
+}
+
+.home-container {
+  @media only screen and (min-width: 768px) {
+    display: none;
+  }
+
+  padding: 10px;
+  color: var(--color-info-light);
+  text-align: right;
+
+  &-icon {
+    transform: rotate(0deg);
+    transition: transform 0.5s ease-in-out;
+
+    &-expanded {
+      transform: rotate(-180deg);
+      transition: transform 0.5s ease-in-out
     }
   }
 }


### PR DESCRIPTION
## Description

Add possibility to hide/show home-container.
Works in both, mobile and desktop layouts through new home-container header IconAngleDown-button.

## Context

Refs HUL-23

## Screenshots
Home-container hidden:
![homecontainer hidden](https://github.com/City-of-Helsinki/outdoors-sports-map/assets/2784933/b977e933-d1ab-4320-8d21-3a448f03ff83)

Home-container shown:
![homecontainer shown](https://github.com/City-of-Helsinki/outdoors-sports-map/assets/2784933/c8c4ab18-6080-480b-bf77-d0d0e1f5e06d)

