### PR TITLE
Update map zooming

### DIFF
--- a/src/domain/home/HomeContainer.tsx
+++ b/src/domain/home/HomeContainer.tsx
@@ -102,20 +102,20 @@ function HomeContainer() {
 
         if (adjustedCenter) {
           leafletElement?.setView(adjustedCenter);
-          //if the geometry is a MultiLineString, then zoom in to the bounds of the geometry
-          if(unit.geometry.type === 'MultiLineString') {
-            //get a flat array of coordinates
+          if (unit.geometry.type === 'MultiLineString') {
+            // if the geometry is a MultiLineString, then zoom in to the bounds of the geometry
+            // get a flat array of coordinates
             const coordinates = unit.geometry.coordinates.flat();
-            //get the maximum latitude and longitude
+            // get the maximum latitude and longitude
             const maxLat = Math.max(...coordinates.map((coord:number[]) => coord[0])),
             minLat = Math.min(...coordinates.map((coord:number[]) => coord[0])),
             maxLng = Math.max(...coordinates.map((coord:number[]) => coord[1])),
             minLng = Math.min(...coordinates.map((coord:number[]) => coord[1]));
-            //set the zoom and fit the bounds of the coordinates
+            // set the zoom and fit the bounds of the coordinates
             leafletElement?.setZoom(DETAIL_ZOOM_IN);
             leafletElement?.fitBounds([[minLat, minLng], [maxLat, maxLng]]);
-            //if the geometry is a point, then zoom in to that point
-          }else{
+          } else {
+            // if the geometry is a point, then zoom in to that point
             const coordinates = unit.location.coordinates;
             leafletElement?.flyTo([coordinates[1], coordinates[0]], DETAIL_ZOOM_IN);
           }

--- a/src/domain/map/mapConstants.ts
+++ b/src/domain/map/mapConstants.ts
@@ -18,11 +18,11 @@ export const MAP_RETINA_URL = {
 
 export const DEFAULT_ZOOM = 12;
 
-export const MIN_ZOOM = 11;
+export const MIN_ZOOM = 10;
 
 export const MAX_ZOOM = 18;
 
-export const DETAIL_ZOOM_IN = 14;
+export const DETAIL_ZOOM_IN = 15;
 
 export const BOUNDARIES: LatLngBoundsLiteral = [
   [59.4, 23.8],

--- a/src/domain/unit/browser/UnitBrowserAddressBar.tsx
+++ b/src/domain/unit/browser/UnitBrowserAddressBar.tsx
@@ -17,7 +17,6 @@ function UnitBrowserAddressBarProps({ address, handleClick }: Props) {
       className="address-bar__container"
       onClick={() => {
         const [long, lat] = address.location.coordinates;
-
         handleClick([lat, long]);
       }}
     >


### PR DESCRIPTION
## Description

Update map zooming:
- Increase detail zoom in level to 15. This will remove previous map jumps to different place.
- Decrease min zoom to level 10. This will allow user to zoom farther away
to see more at once with smaller screens.

Refs HUL-16

## Screenshots

Previously selecting `Hakunila-Bisajärvi hiihtolatu 4,5km` zoomed map to Estonia coastline.
Now the map stays in Finland and zooms to correct unit.

<img width="967" alt="map zoom fix" src="https://github.com/City-of-Helsinki/outdoors-sports-map/assets/2784933/f5468448-f7f8-4b31-9872-b039e9f86c7b">


