### PR TITLE
Save units as favorites

### DIFF
--- a/src/domain/app/useAppSearch.ts
+++ b/src/domain/app/useAppSearch.ts
@@ -2,10 +2,11 @@ import { useLocation } from "react-router";
 
 import useSearch from "../../common/hooks/useSearch";
 import { AppSearch, AppSearchLocationState } from "../app/appConstants";
-import { SortKeys, UNIT_BATCH_SIZE } from "../unit/unitConstants";
+import { SortKeys, Unit, UNIT_BATCH_SIZE } from "../unit/unitConstants";
 import {
   getDefaultSportFilter,
   getDefaultStatusFilter,
+  getUnitSport,
 } from "../unit/unitHelpers";
 
 function useAppSearch() {
@@ -19,11 +20,31 @@ function useAppSearch() {
     sport = state?.search?.sport || getDefaultSportFilter(),
     status = state?.search?.status || getDefaultStatusFilter(),
     sportSpecification = state?.search?.sportSpecification || "",
-    sortKey = state?.search?.sortKey || SortKeys.CONDITION,
+    sortKey = state?.search?.sortKey,
     maxUnitCount = state?.search?.maxUnitCount || UNIT_BATCH_SIZE.toString(),
   } = useSearch<AppSearch>();
 
-  return { q, sport, status, sportSpecification, sortKey, maxUnitCount };
+  const favourites = JSON.parse(localStorage.getItem("favouriteUnits") || "[]");
+  const selectedSport = sport;
+  const sportFavourites = favourites.filter(
+    (favourite: Unit) => getUnitSport(favourite) === selectedSport,
+  );
+
+  // If there are favourites, sort by them by default, otherwise sort by condition
+  const defaultSortKey =
+    sportFavourites.length > 0 ? SortKeys.FAVORITES : SortKeys.CONDITION;
+
+  // Use defaultSortKey if sortKey is not defined
+  const finalSortKey = sortKey || defaultSortKey;
+
+  return {
+    q,
+    sport,
+    status,
+    sportSpecification,
+    sortKey: finalSortKey,
+    maxUnitCount,
+  };
 }
 
 export default useAppSearch;

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -72,7 +72,8 @@
       "DEFAULT": "Default",
       "ALPHABETICAL": "Alphabetic",
       "CONDITION": "In best condition first",
-      "DISTANCE": "Closest first"
+      "DISTANCE": "Closest first",
+      "FAVORITES": "Favorites"
     },
     "PHONE": "Phone",
     "TMP_MESSAGE": "",

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -96,6 +96,7 @@
     "NOT_FOUND": "Sorry, the object was not found :(",
     "QUALITY": "Condition",
     "ADD_FAVOURITE": "Add to favourites",
+    "REMOVE_FAVOURITE": "Remove from favourites",
     "INFO": "Information",
     "WEATHER": "Weather",
     "HEIGHT_PROFILE": "Height profile",

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -44,6 +44,7 @@
     "FURTHER_INFO": "Further information",
     "SHOW_MORE": "Show more",
     "SHOW_LESS": "Show less",
+    "NO_FAVORITES": "No favorites",
     "STATUS": "Condition",
     "UNKNOWN": "Unknown",
     "SATISFACTORY": "Decent",

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -95,6 +95,7 @@
     "LOADING": "Loading the object",
     "NOT_FOUND": "Sorry, the object was not found :(",
     "QUALITY": "Condition",
+    "ADD_FAVOURITE": "Add to favourites",
     "INFO": "Information",
     "WEATHER": "Weather",
     "HEIGHT_PROFILE": "Height profile",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -72,7 +72,8 @@
       "DEFAULT": "Oletus",
       "ALPHABETICAL": "Aakkosellinen",
       "CONDITION": "Paras kunto ensin",
-      "DISTANCE": "Lähimmät ensin"
+      "DISTANCE": "Lähimmät ensin",
+      "FAVORITES": "Suosikit"
     },
     "PHONE": "Puhelinnumero",
     "TMP_MESSAGE": "",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -44,6 +44,7 @@
     "FURTHER_INFO": "Lisää tietoa",
     "SHOW_MORE": "Näytä enemmän",
     "SHOW_LESS": "Näytä vähemmän",
+    "NO_FAVORITES": "Ei suosikkeja",
     "STATUS": "Kunto",
     "UNKNOWN": "Tuntematon",
     "SATISFACTORY": "Tyydyttävä",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -96,6 +96,7 @@
     "NOT_FOUND": "Pahoittelut, kohdetta ei löytynyt :(",
     "QUALITY": "Kunto",
     "ADD_FAVOURITE": "Lisää suosikiksi",
+    "REMOVE_FAVOURITE": "Poista suosikeista",
     "INFO": "Info",
     "WEATHER": "Sää",
     "HEIGHT_PROFILE": "Korkeusprofiili",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -95,6 +95,7 @@
     "LOADING": "Ladataan kohdetta...",
     "NOT_FOUND": "Pahoittelut, kohdetta ei löytynyt :(",
     "QUALITY": "Kunto",
+    "ADD_FAVOURITE": "Lisää suosikiksi",
     "INFO": "Info",
     "WEATHER": "Sää",
     "HEIGHT_PROFILE": "Korkeusprofiili",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -72,7 +72,8 @@
       "DEFAULT": "Förinställt",
       "ALPHABETICAL": "Alfabetisk",
       "CONDITION": "I bästa skick först",
-      "DISTANCE": "Närmast först"
+      "DISTANCE": "Närmast först",
+      "FAVORITES": "Favoriter"
     },
     "PHONE": "Telefon",
     "TMP_MESSAGE": "",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -96,6 +96,7 @@
     "NOT_FOUND": "Beklagar, objektet hittades inte :(",
     "QUALITY": "Skick",
     "ADD_FAVOURITE": "Lägg till som favorit",
+    "REMOVE_FAVOURITE": "Ta bort som favorit",
     "INFO": "Information",
     "WEATHER": "Väder",
     "HEIGHT_PROFILE": "Höjdprofil",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -44,6 +44,7 @@
     "FURTHER_INFO": "Ytterligare upplysningar",
     "SHOW_MORE": "Visa mer",
     "SHOW_LESS": "Visa mindre",
+    "NO_FAVORITES": "Inga favoriter",
     "STATUS": "Skick",
     "UNKNOWN": "Okänt",
     "SATISFACTORY": "Hyfsad",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -95,6 +95,7 @@
     "LOADING": "Laddar objekt",
     "NOT_FOUND": "Beklagar, objektet hittades inte :(",
     "QUALITY": "Skick",
+    "ADD_FAVOURITE": "Lägg till som favorit",
     "INFO": "Information",
     "WEATHER": "Väder",
     "HEIGHT_PROFILE": "Höjdprofil",

--- a/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
+++ b/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
@@ -85,6 +85,8 @@ function UnitBrowserResultList({ leafletMap }: Props) {
     leafletMap,
   });
 
+  const totalUnitResults = sortKey === "favorites" ? results?.length : totalUnits;
+
   const handleOnSortKeySelect = useCallback(
     (nextSortKey) => {
       if (nextSortKey) {
@@ -122,25 +124,31 @@ function UnitBrowserResultList({ leafletMap }: Props) {
         <div className="list-view__block">
           {results === null && <Loading />}
           {Array.isArray(results) && (
-            <>
-              {results.map((unit) => (
-                <UnitListItem key={unit.id} unit={unit} />
-              ))}
-              {results.length !== totalUnits && ( // eslint-disable-next-line jsx-a11y/anchor-is-valid
-                <a
-                  style={{
-                    display: "block",
-                    textAlign: "center",
-                    cursor: "pointer",
-                    margin: "18px auto 10px",
-                  }}
-                  href=""
-                  onClick={handleLoadMoreClick}
-                >
-                  {t("UNIT_DETAILS.SHOW_MORE")}
-                </a>
-              )}
-            </>
+          <>
+            {results.length === 0 && sortKey === 'favorites' ? (
+              <p style={{ textAlign: "center" }}>{t("UNIT_DETAILS.NO_FAVORITES")}</p>
+            ) : (
+              <>
+                {results.map((unit) => (
+                  <UnitListItem key={unit.id} unit={unit} />
+                ))}
+                {results.length !== totalUnitResults && ( // eslint-disable-next-line jsx-a11y/anchor-is-valid
+                  <a
+                    style={{
+                      display: "block",
+                      textAlign: "center",
+                      cursor: "pointer",
+                      margin: "18px auto 10px",
+                    }}
+                    href=""
+                    onClick={handleLoadMoreClick}
+                  >
+                    {t("UNIT_DETAILS.SHOW_MORE")}
+                  </a>
+                )}
+              </>
+            )}
+          </>
           )}
         </div>
       </div>

--- a/src/domain/unit/browser/resultList/__tests__/UnitBrowserResultList.test.tsx
+++ b/src/domain/unit/browser/resultList/__tests__/UnitBrowserResultList.test.tsx
@@ -159,3 +159,34 @@ describe("<UnitBrowserResultList />", () => {
     });
   });
 });
+
+describe("<UnitBrowserResultListSort />", () => {
+  it("should render sort by condition by default", () => {
+    const wrapper = getWrapper();
+    expect(wrapper.text().includes("Paras kunto ensin")).toEqual(true)
+  });
+
+  it("should render favorites by default if user has saved favorites", () => {
+    // Add unit to favourites
+    const favouriteUnit = units["53916"];
+    localStorage.setItem('favouriteUnits', JSON.stringify([favouriteUnit]));
+
+    const wrapper = getWrapper();
+    expect(wrapper.text().includes("Suosikit")).toEqual(true)
+
+    // Clean up
+    localStorage.removeItem('favouriteUnits');
+  });
+
+  it("should render sort by condition if user has favorites but not in selected sport", () => {
+    // Add unit to favourites
+    const favouriteUnit = {"id": 12345, "name": {"fi": "Testi tekojääkenttä" }, "services": [406]};
+    localStorage.setItem('favouriteUnits', JSON.stringify([favouriteUnit]));
+
+    const wrapper = getWrapper();
+    expect(wrapper.text().includes("Paras kunto ensin")).toEqual(true)
+
+    // Clean up
+    localStorage.removeItem('favouriteUnits');
+  });
+});

--- a/src/domain/unit/browser/resultList/useUnitSearchResults.ts
+++ b/src/domain/unit/browser/resultList/useUnitSearchResults.ts
@@ -35,6 +35,10 @@ function sortUnits({ units, position, leafletMap, sortKey }: SortOptions) {
       sortedUnits = unitHelpers.sortByDistance(units, position, leafletMap);
       break;
 
+    case SortKeys.FAVORITES:
+      sortedUnits = unitHelpers.sortByFavorites(units);
+      break;
+
     default:
       sortedUnits = units;
   }

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -1,7 +1,7 @@
-import { IconAngleDown } from "hds-react";
+import { IconAngleDown, IconStar, IconStarFill } from "hds-react";
 import get from "lodash/get";
 import has from "lodash/has";
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
@@ -122,6 +122,48 @@ export function MobileFooter({ toggleExpand, isExpanded }: MobileFooterProps) {
       </div>
   </div>)
 }
+
+function isUnitInFavourites(unit: Unit): boolean {
+  const favourites = JSON.parse(localStorage.getItem('favouriteUnits') || '[]');
+  return favourites.some((favourite: Unit) => favourite.id === unit.id);
+}
+
+function handleAddToFavourites(unit: Unit) {
+  if (!isUnitInFavourites(unit)) {
+    const favourites = JSON.parse(localStorage.getItem('favouriteUnits') || '[]');
+    favourites.push(unit);
+    localStorage.setItem('favouriteUnits', JSON.stringify(favourites));
+  };
+};
+
+type AddFavoriteProps = {
+  unit: Unit;
+};
+
+function AddFavorite({ unit }: AddFavoriteProps) {
+  const { t } = useTranslation();
+  const [isFavourite, setIsFavourite] = useState(false);
+  
+  useEffect(() => {
+    setIsFavourite(isUnitInFavourites(unit));
+  }, [unit]);
+
+  const handleClick = () => {
+    handleAddToFavourites(unit);
+    setIsFavourite(true);
+  };
+
+  return (
+    <BodyBox title="">
+      <button className="favorite-button" onClick={handleClick}>
+        <span className="favorite-button-content">
+          <span>{t("UNIT_BROWSER.ADD_FAVOURITE")}</span>
+          {isFavourite ? <IconStarFill /> : <IconStar />}
+        </span>
+      </button>
+    </BodyBox>
+  )
+} 
 
 type LocationStateProps = {
   unit: Unit;
@@ -521,6 +563,7 @@ export function SingleUnitBody({
   return currentUnit && !isLoading ? (
     <div className="unit-container-body">
       <LocationState unit={currentUnit} />
+      <AddFavorite unit={currentUnit} />
       <NoticeInfo unit={currentUnit} />
       {!liveTemperatureObservation && temperatureObservation && (
         <LocationTemperature observation={temperatureObservation} />

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -128,12 +128,19 @@ function isUnitInFavourites(unit: Unit): boolean {
   return favourites.some((favourite: Unit) => favourite.id === unit.id);
 }
 
-function handleAddToFavourites(unit: Unit) {
-  if (!isUnitInFavourites(unit)) {
-    const favourites = JSON.parse(localStorage.getItem('favouriteUnits') || '[]');
+function toggleFavourite(unit: Unit) {
+  const favourites = JSON.parse(localStorage.getItem('favouriteUnits') || '[]');
+  const unitIndex = favourites.findIndex((favourite: Unit) => favourite.id === unit.id);
+
+  if (unitIndex === -1) {
+    // Add the unit to favourites
     favourites.push(unit);
-    localStorage.setItem('favouriteUnits', JSON.stringify(favourites));
-  };
+  } else {
+    // Remove the unit from favourites
+    favourites.splice(unitIndex, 1);
+  }
+
+  localStorage.setItem('favouriteUnits', JSON.stringify(favourites));
 };
 
 type AddFavoriteProps = {
@@ -149,15 +156,15 @@ function AddFavorite({ unit }: AddFavoriteProps) {
   }, [unit]);
 
   const handleClick = () => {
-    handleAddToFavourites(unit);
-    setIsFavourite(true);
+    toggleFavourite(unit);
+    setIsFavourite(!isFavourite);
   };
 
   return (
     <BodyBox title="">
       <button className="favorite-button" onClick={handleClick}>
         <span className="favorite-button-content">
-          <span>{t("UNIT_BROWSER.ADD_FAVOURITE")}</span>
+          <span>{isFavourite ? t("UNIT_BROWSER.REMOVE_FAVOURITE") : t("UNIT_BROWSER.ADD_FAVOURITE")}</span>
           {isFavourite ? <IconStarFill /> : <IconStar />}
         </span>
       </button>

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -546,3 +546,20 @@ describe("<UnitDetails />", () => {
     expect(wrapperText.includes("Hiihtotyyli: Vapaa Koiralatu")).toEqual(true);
   });
 });
+
+it("should render 'Lisää suosikiksi' button", () => {
+  const wrapper = getWrapper();
+  expect(wrapper.find('button').text().includes("Lisää suosikiksi")).toEqual(true);
+});
+
+it("should render 'Poista suosikeista' button if unit is already in favourites", () => {
+  // Add unit to favourites
+  const favouriteUnit = unit;
+  localStorage.setItem('favouriteUnits', JSON.stringify([unit]));
+
+  const wrapper = getWrapper({ unit: favouriteUnit });
+  expect(wrapper.find('button').text().includes("Poista suosikeista")).toEqual(true);
+
+  // Clean up local storage
+  localStorage.removeItem('favouriteUnits');
+});

--- a/src/domain/unit/details/_unitDetails.scss
+++ b/src/domain/unit/details/_unitDetails.scss
@@ -171,3 +171,22 @@
     background-color: #a8b5c2;
   }
 }
+
+.favorite-button {
+  background: none;
+  color: #0d6efd;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  display: block;
+  width: 100%;
+  text-align: left;
+}
+
+.favorite-button-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/src/domain/unit/unitConstants.ts
+++ b/src/domain/unit/unitConstants.ts
@@ -208,6 +208,7 @@ export const SortKeys = {
   ALPHABETICAL: "alphabetical",
   DISTANCE: "distance",
   CONDITION: "condition",
+  FAVORITES: "favorites",
 } as const;
 
 export type SortKey = (typeof SortKeys)[keyof typeof SortKeys];

--- a/src/domain/unit/unitHelpers.ts
+++ b/src/domain/unit/unitHelpers.ts
@@ -372,6 +372,13 @@ export const sortByCondition = (units: Unit[]) =>
     },
   ]);
 
+export const sortByFavorites = (units: Unit[]): Unit[] => {
+  const favourites = JSON.parse(localStorage.getItem("favouriteUnits") || "[]");
+  return units.filter((unit) =>
+    favourites.some((favourite: Unit) => favourite.id === unit.id),
+  );
+};
+
 export const getAddressToDisplay = (
   address: Record<string, any>,
   activeLang: string,


### PR DESCRIPTION
## Description

Add a new feature to save units as favorites. Favorites are stored in local storage. User can add or remove units from favorites in the unit details view. Favorites are displayed in the unit search results view when the favorites filter is selected. If user has favorites in the selected sport, the list is sorted by favorites by default.

## Context

Refs HUL-28

## How Has This Been Tested?

Feature has been tested locally and also by some unit tests.

## Screenshots

Adding a favorite:
<img width="350" alt="add_fav" src="https://github.com/user-attachments/assets/15fa3441-f1de-4deb-acf9-f8ad0666c030">

Removing a favorite:
<img width="350" alt="del_fav" src="https://github.com/user-attachments/assets/3712e77a-9c0a-444b-89c2-458e6d225d5a">

Favorites filter:
<img width="350" alt="favorites" src="https://github.com/user-attachments/assets/14df0653-5695-4476-8abe-1c89ccf5bf44">






