### PR TITLE
Validate currentLanguage in CookieConsent

### DIFF
--- a/src/domain/app/CookieConsent.tsx
+++ b/src/domain/app/CookieConsent.tsx
@@ -9,10 +9,11 @@ declare global {
 
 function CookieConsent() {
   const { t, i18n } = useTranslation();
+  const currentLanguage = ['fi', 'sv', 'en'].includes(i18n.language) ? i18n.language : 'en';
 
   const contentSource: ContentSource = {
     siteName: t("APP.NAME"),
-    currentLanguage:  i18n.language as 'fi' | 'sv' | 'en',
+    currentLanguage:  currentLanguage as 'fi' | 'sv' | 'en',
     optionalCookies: {
       groups: [
         {


### PR DESCRIPTION
## Description

Ensure `currentLanguage` is either 'fi', 'sv', or 'en' in the CookieConsent component and default to 'en' if not. This fixes issue where the page was white/blank on the first load due to incorrect language type.

## Context

Refs HUL-29

