### PR TITLE
Hul 64 targeting control is inadequate

### DIFF
--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -61,6 +61,7 @@
     "BACK": "Back",
     "FURTHER_INFO": "Further information",
     "SHOW_MORE": "Show more",
+    "RESULTS_LOADED": "Showing {{shown}} of {{total}} results",
     "SHOW_LESS": "Show less",
     "NO_FAVORITES": "No favorites",
     "NO_RESULTS": "No results found",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -61,6 +61,7 @@
     "BACK": "Takaisin",
     "FURTHER_INFO": "Lisää tietoa",
     "SHOW_MORE": "Näytä enemmän",
+    "RESULTS_LOADED": "Näytetään {{shown}} / {{total}} tulosta",
     "SHOW_LESS": "Näytä vähemmän",
     "NO_FAVORITES": "Ei suosikkeja",
     "NO_RESULTS": "Ei hakutuloksia",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -61,6 +61,7 @@
     "BACK": "Tillbaka",
     "FURTHER_INFO": "Ytterligare upplysningar",
     "SHOW_MORE": "Visa mer",
+    "RESULTS_LOADED": "Visar {{shown}} av {{total}} resultat",
     "SHOW_LESS": "Visa mindre",
     "NO_FAVORITES": "Inga favoriter",
     "NO_RESULTS": "Inga sökresultat",

--- a/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
+++ b/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
@@ -74,8 +74,6 @@ function UnitBrowserResultList({ leafletMap }: Props) {
   const { t } = useTranslation();
   const { q, sortKey, maxUnitCount } = useAppSearch();
   const doSearch = useDoSearch();
-  const headingRef = useRef<HTMLHeadingElement>(null);
-  const prevResultsNullRef = useRef(true);
 
   const { totalUnits, results } = useUnitSearchResults({
     sortKey,
@@ -83,14 +81,40 @@ function UnitBrowserResultList({ leafletMap }: Props) {
     leafletMap,
   });
 
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const prevResultsNullRef = useRef(true);
+  const listRef = useRef<HTMLDivElement>(null);
+  const announcementRef = useRef<HTMLDivElement>(null);
+  const firstNewItemIndexRef = useRef<number | null>(null);
+
   useEffect(() => {
     const wasLoading = prevResultsNullRef.current;
     prevResultsNullRef.current = results === null;
 
-    if (wasLoading && results !== null && q) {
+    if (
+      firstNewItemIndexRef.current !== null &&
+      Array.isArray(results) &&
+      results.length > firstNewItemIndexRef.current
+    ) {
+      const index = firstNewItemIndexRef.current;
+      firstNewItemIndexRef.current = null;
+
+      const items =
+        listRef.current?.querySelectorAll<HTMLElement>(".list-view-item");
+      const firstNewItem = items?.[index];
+      firstNewItem?.scrollIntoView({ block: "start", behavior: "smooth" });
+      firstNewItem?.focus({ preventScroll: true });
+
+      if (announcementRef.current) {
+        announcementRef.current.textContent = t("UNIT_DETAILS.RESULTS_LOADED", {
+          shown: results.length,
+          total: totalUnits,
+        });
+      }
+    } else if (wasLoading && results !== null && q) {
       headingRef.current?.focus();
     }
-  }, [results, q]);
+  }, [results, q, totalUnits, t]);
 
   const handleOnSortKeySelect = useCallback(
     (nextSortKey: string | null) => {
@@ -108,12 +132,14 @@ function UnitBrowserResultList({ leafletMap }: Props) {
     (e: React.SyntheticEvent<HTMLButtonElement>) => {
       e.preventDefault();
 
+      firstNewItemIndexRef.current = results?.length ?? 0;
+
       doSearch(
         "maxUnitCount",
         (Number(maxUnitCount) + UNIT_BATCH_SIZE).toString(),
       );
     },
-    [maxUnitCount, doSearch],
+    [maxUnitCount, doSearch, results],
   );
 
   return (
@@ -133,7 +159,8 @@ function UnitBrowserResultList({ leafletMap }: Props) {
             onSelect={handleOnSortKeySelect}
           />
         </div>
-        <div className="list-view__items-block">
+        <div ref={announcementRef} aria-live="polite" aria-atomic="true" className="sr-only" />
+        <div ref={listRef} className="list-view__items-block">
           {results === null && <Loading />}
           {Array.isArray(results) && (
             <>

--- a/src/domain/unit/browser/resultList/__tests__/UnitBrowserResultList.test.tsx
+++ b/src/domain/unit/browser/resultList/__tests__/UnitBrowserResultList.test.tsx
@@ -133,6 +133,8 @@ beforeEach(() => {
   vi
     .spyOn(unitHelpers, "getDefaultSportFilter")
     .mockImplementation(() => "ski");
+  // jsdom does not implement scrollIntoView
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
 afterEach(() => {
@@ -165,6 +167,41 @@ describe("<UnitBrowserResultList />", () => {
       expect(
         screen.getByText("Mustavuori-Talosaari latu 5,5 km"),
       ).toBeInTheDocument();
+    });
+    it("should move focus to the first new result after loading more", async () => {
+      renderComponent();
+
+      const user = userEvent.setup();
+      await user.click(screen.getByText("Näytä enemmän"));
+
+      const items = document.querySelectorAll(".list-view-item");
+      expect(document.activeElement).toBe(items[1]);
+    });
+    it("should scroll the first new result into view after loading more", async () => {
+      const scrollIntoView = vi.fn();
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      renderComponent();
+
+      const user = userEvent.setup();
+      await user.click(screen.getByText("Näytä enemmän"));
+
+      const items = document.querySelectorAll(".list-view-item");
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: "start",
+        behavior: "smooth",
+      });
+      // Verify it was called on the first new item (index 1)
+      expect(document.activeElement).toBe(items[1]);
+    });
+    it("should announce new results to screen readers after loading more", async () => {
+      renderComponent();
+
+      const user = userEvent.setup();
+      await user.click(screen.getByText("Näytä enemmän"));
+
+      const liveRegion = document.querySelector("[aria-live]");
+      expect(liveRegion).toHaveTextContent(/2.*2/);
     });
   });
 

--- a/src/domain/unit/browser/resultList/_unitBrowserResultList.scss
+++ b/src/domain/unit/browser/resultList/_unitBrowserResultList.scss
@@ -1,3 +1,15 @@
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .list-view {
   overflow: auto;
 


### PR DESCRIPTION
## Description

After clicking "Show more" to load additional search results, keyboard and screen reader users previously had no indication that new results were loaded and their focus remained on the button (which may have disappeared). This change improves the experience by:

- _Focus management_: Moves keyboard focus to the first newly loaded result after clicking "Show more", so keyboard users can immediately navigate the new items.

- _Scroll behavior_: Smoothly scrolls the first new result into view.

- _Live region announcement_: Adds an aria-live="polite" region that announces the updated result count (e.g. "Showing 20 of 50 results") to screen reader users when new results are loaded.

## Context

 Keyboard and screen reader users previously had no indication that new results were loaded and their focus remained on the button (which may have disappeared).

[HUL-64](https://andersinno.atlassian.net/browse/HUL-64)

## Changes

- _UnitBrowserResultList.tsx_ — Added useEffect to handle post-load focus and scroll, tracks the index of the first new item via a ref, and updates an ARIA live region with the current result count.

- __unitBrowserResultList.scss_ — Added .sr-only utility class to visually hide the live region while keeping it accessible to screen readers.

- _en.json / fi.json / sv.json_ — Added RESULTS_LOADED translation key for the live region announcement.

- _UnitBrowserResultList.test.tsx_ — Added tests covering focus move, scroll invocation, and screen reader announcement after loading more results.

## How Has This Been Tested?

Added tests covering focus move, scroll invocation, and screen reader announcement after loading more results.

## Manual Testing Instructions for Reviewers

click on Search --> Scroll to bottom of the search result  --> Click on Show more --> you should see the new results loaded and focus jumping to the start of the search.

## Screenshots

https://github.com/user-attachments/assets/580fa79a-e591-4127-849f-edfb2f7c56fd


