### PR TITLE
Hul 61 the page language setting is not being passed on correctly to accessibility users

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,18 @@
 <html lang="fi">
   <head>
     <meta charset="utf-8" />
+    <script>
+      // Set the correct lang attribute synchronously from the URL path before
+      // any JS bundle loads. This prevents screen readers from latching onto 
+      // the hard-coded "fi" default when the user loads a non-Finnish page directly. 
+      // Matches /fi/, /sv/, or /en/ path segments.
+      (function () {
+        var match = window.location.pathname.match(/^\/(fi|sv|en)(\/|$)/);
+        if (match) {
+          document.documentElement.lang = match[1];
+        }
+      })();
+    </script>
 
     <link rel="icon" href="/favicon.ico" />
     <link

--- a/src/domain/app/AppHeader.tsx
+++ b/src/domain/app/AppHeader.tsx
@@ -7,7 +7,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { useHistory, useLocation } from "react-router-dom";
+import { useLocation, useRouteMatch } from "react-router-dom";
 
 import AppAboutModal from "./AppAboutModal";
 import AppAccessibilityModal from "./AppAccessibilityModal";
@@ -48,12 +48,13 @@ function ApplicationHeader({
 }: Readonly<ApplicationHeaderProps>) {
   const { t } = useTranslation();
   const locale = useLocale();
+  const match = useRouteMatch<{ language: string }>();
+  const routeLanguage = match?.params?.language ?? locale;
   const isMobile = useIsMobile();
   const openInNewTabAriaLabel = t("OUTBOUND_LINK.OPEN_IN_NEW_TAB");
   const osmLinkLabel = t("APP.MAP_ATTRIBUTION");
   const osmLinkLabelAria = `${osmLinkLabel}. ${openInNewTabAriaLabel}`;
 
-  const history = useHistory();
   const { pathname } = useLocation();
 
   // Reference to the link which was clicked before opening a modal, to return
@@ -140,13 +141,13 @@ function ApplicationHeader({
     <>
       <Header
         id={HEADER_ID}
+        key={routeLanguage}
         lang={locale}
         className="app-header"
-        defaultLanguage={locale}
+        defaultLanguage={routeLanguage}
         languages={languages}
         onDidChangeLanguage={(lng) => {
-          const newPath = replaceLanguageInPath(pathname, lng);
-          history.push({ pathname: newPath });
+          globalThis.location.assign(replaceLanguageInPath(pathname, lng));
         }}
       >
         <Header.SkipLink

--- a/src/domain/app/AppLanguageAwareRoutes.tsx
+++ b/src/domain/app/AppLanguageAwareRoutes.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
-import { useTranslation } from "react-i18next";
 import { Route, useRouteMatch } from "react-router-dom";
 
 import useLanguage from "../../common/hooks/useLanguage";
+import { replaceLanguageInPath } from "../../common/utils/pathUtils";
 import HomeContainer from "../home/HomeContainer";
 import { languageParam } from "../i18n/i18nConstants";
 
@@ -16,18 +16,19 @@ function getRouteLanguage(match: Record<string, any> | null | undefined) {
 }
 
 function LanguageAwareRoutes() {
-  const { i18n } = useTranslation();
   const language = useLanguage();
 
   const match = useRouteMatch();
   const routeLanguage = getRouteLanguage(match);
 
   useEffect(() => {
-    // Sync language with i18next in case it is changed by changing the url
-    if (language !== routeLanguage) {
-      i18n.changeLanguage(routeLanguage);
+    // When the URL language differs from the active language (e.g. browser
+    // back/forward across language versions), do a full page reload so the
+    // browser receives the page with the correct lang attribute from the start.
+    if (routeLanguage && language !== routeLanguage) {
+      globalThis.location.replace(replaceLanguageInPath(globalThis.location.pathname, routeLanguage));
     }
-  }, [routeLanguage, language, i18n]);
+  }, [routeLanguage, language]);
 
   return <Route path={`/${languageParam}`} component={HomeContainer} />;
 }


### PR DESCRIPTION
## Description

Synchronize the HTML lang attribute with the active application language during browser navigation and language switching. This ensures that screen readers and assistive technologies receive the correct language context, improving accessibility for users relying on text-to-speech and other accessibility features.

## Context

Users relying on accessibility tools (screen readers, text-to-speech) were not receiving proper language information when navigating through the browser or switching languages via the app header. The HTML lang attribute was not being correctly synchronized with the active language, causing screen readers to announce content in the wrong language or using default language(fi).

This impacts user experience for accessibility-dependent users.
[HUL-61](https://andersinno.atlassian.net/browse/HUL-61)
## Changes

- `index.html` -Added inline script to set lang attribute synchronously from URL path before JS bundle loads

- `AppHeader.tsx`- Improved language switching to use full page reload instead of history push

- `AppLanguageAwareRoutes.tsx` - Synced route language with page language via full page reload

## How Has This Been Tested?

  - Verify language state synchronization with URL parameters
  
  - Confirm language changes are reflected in the DOM lang attribute
  
  - Test with screen readers (Orca) to validate correct language announcement
  
  - Browser navigation (back/forward buttons) tested to ensure language persistence
  
  - Language switcher in app header tested across all supported languages

## Manual Testing Instructions for Reviewers

1. Test language persistence on browser navigation:

    - Open the app and select a language (e.g., Swedish /sv/)
    
    - Navigate to a unit detail page
    
    - Click browser back button
    
    - Verify the URL contains the correct language prefix and <html lang="sv"> is set

2. Test language switching via app header:

    - Open the app in one language
    
    - Click the language switcher in the header
    
    - Confirm the URL updates with the new language code
    
    - Inspect the <html> element and verify lang attribute matches the selected language

3. Test with screen reader (if available):

    - Enable a screen reader (NVDA, JAWS, Orca etc)
    
    - Navigate through the app switching languages
    
    - Verify the screen reader announces content in the correct language

3. Test language switching on different pages:

    - Visit home page, search results, and unit details pages
    
    - Switch languages on each page
    
    - Confirm language changes propagate consistently

## Screenshots


https://github.com/user-attachments/assets/98ace816-ea60-446d-93a7-bb2b991a48a5


