### PR TITLE
Hul 62 the height profile is not accessible with assistive devices

### DIFF
--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -124,6 +124,8 @@
     "OPENING_HOURS": "Opening hours",
     "ROUTE_LENGTH": "Route length",
     "LIT_ROUTE_LENGTH": "Lit route length",
+    "HIGHEST_POINT": "Highest point",
+    "LOWEST_POINT": "Lowest point",
     "SKIING_TECHNIQUE": "Form of skiing",
     "SKIING_TECHNIQUE_FREESTYLE": "Freestyle",
     "SKIING_TECHNIQUE_TRADITIONAL": "Classic",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -125,6 +125,8 @@
     "OPENING_HOURS": "Aukioloajat",
     "ROUTE_LENGTH": "Reitin pituus",
     "LIT_ROUTE_LENGTH": "Valaistu reitti",
+    "HIGHEST_POINT": "Korkein kohta",
+    "LOWEST_POINT": "Matalin kohta",
     "SKIING_TECHNIQUE": "Hiihtotyyli",
     "SKIING_TECHNIQUE_FREESTYLE": "Vapaa",
     "SKIING_TECHNIQUE_TRADITIONAL": "Perinteinen",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -124,6 +124,8 @@
     "OPENING_HOURS": "Öppettider",
     "ROUTE_LENGTH": "Spårets längd",
     "LIT_ROUTE_LENGTH": "Upplyst spårets längd",
+    "HIGHEST_POINT": "Högsta punkt",
+    "LOWEST_POINT": "Lägsta punkt",
     "SKIING_TECHNIQUE": "Åkstil",
     "SKIING_TECHNIQUE_FREESTYLE": "Fristil",
     "SKIING_TECHNIQUE_TRADITIONAL": "Klassisk",

--- a/src/domain/map/HeightProfileControl.ts
+++ b/src/domain/map/HeightProfileControl.ts
@@ -126,6 +126,8 @@ function HeightProfileControl({ unit }: Props) {
     const displayGroup = new L.LayerGroup();
     displayGroup.addTo(map);
     control.addTo(map);
+    // Set aria-hidden to true for the control container to hide it from screen readers
+    control.getContainer().setAttribute("aria-hidden", "true");
     control.addData(geoJson);
 
     const layer = L.geoJson(geoJson, {

--- a/src/domain/unit/details/UnitDetails.tsx
+++ b/src/domain/unit/details/UnitDetails.tsx
@@ -7,7 +7,6 @@ import {
   Tag,
 } from "hds-react";
 import get from "lodash/get";
-import has from "lodash/has";
 import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
@@ -40,6 +39,7 @@ import { selectUnitById, useGetUnitByIdQuery } from "../state/unitSlice";
 import { Translatable, Unit } from "../types";
 import { UnitConnectionTags } from "../unitConstants";
 import {
+  calculateElevationStats,
   createPalvelukarttaUrl,
   createReittiopasUrl,
   getAttr,
@@ -47,7 +47,10 @@ import {
   getObservation,
   getObservationTime,
   getOpeningHours,
+  getUnitObservations,
   handleSingleUnitConditionUpdate,
+  isUnitInFavourites,
+  toggleFavourite,
 } from "../unitHelpers";
 
 type HeaderProps = {
@@ -165,28 +168,6 @@ export function MobileFooter({
   );
 }
 
-function isUnitInFavourites(unit: Unit): boolean {
-  const favourites = JSON.parse(localStorage.getItem("favouriteUnits") || "[]");
-  return favourites.some((favourite: Unit) => favourite.id === unit.id);
-}
-
-function toggleFavourite(unit: Unit) {
-  const favourites = JSON.parse(localStorage.getItem("favouriteUnits") || "[]");
-  const unitIndex = favourites.findIndex(
-    (favourite: Unit) => favourite.id === unit.id,
-  );
-
-  if (unitIndex === -1) {
-    // Add the unit to favourites
-    favourites.push(unit);
-  } else {
-    // Remove the unit from favourites
-    favourites.splice(unitIndex, 1);
-  }
-
-  localStorage.setItem("favouriteUnits", JSON.stringify(favourites));
-}
-
 type AddFavoriteProps = {
   unit: Unit;
 };
@@ -258,6 +239,12 @@ function LocationInfo({ unit }: LocationInfoProps) {
     unit,
     ["extra", "lipas.skiTrackTraditional"],
     null,
+  );
+
+  // Calculate elevation stats if 3D geometry is available
+  const elevationStats = useMemo(
+    () => calculateElevationStats(unit.geometry_3d),
+    [unit.geometry_3d],
   );
 
   const hasExtras =
@@ -375,6 +362,19 @@ function LocationInfo({ unit }: LocationInfoProps) {
             <span>{value}km</span>
           </p>
         ))}
+      {/* Elevation stats */}
+      {elevationStats && (
+        <>
+          <p className="small-margin">
+            {`${t("UNIT_BROWSER.HIGHEST_POINT")}: `}
+            <span>{elevationStats.highest.toFixed(1)}m</span>
+          </p>
+          <p className="small-margin">
+            {`${t("UNIT_BROWSER.LOWEST_POINT")}: `}
+            <span>{elevationStats.lowest.toFixed(1)}m</span>
+          </p>
+        </>
+      )}
 
       {/* Connection details */}
       {[
@@ -673,23 +673,6 @@ type Props = {
   isExpanded: boolean;
   toggleIsExpanded: () => void;
 };
-
-// Helper function to extract observations from unit
-function getUnitObservations(unit: Unit | undefined) {
-  if (!unit || !has(unit, "observations")) {
-    return {
-      temperatureObservation: null,
-      liveTemperatureObservation: null,
-      liveWaterQualityObservation: null,
-    };
-  }
-
-  return {
-    temperatureObservation: getObservation(unit, "swimming_water_temperature"),
-    liveTemperatureObservation: getObservation(unit, "live_swimming_water_temperature"),
-    liveWaterQualityObservation: getObservation(unit, "live_swimming_water_quality"),
-  };
-}
 
 type UnitNotFoundProps = {
   headerHeight: number;

--- a/src/domain/unit/details/__tests__/UnitDetails.test.tsx
+++ b/src/domain/unit/details/__tests__/UnitDetails.test.tsx
@@ -688,6 +688,52 @@ describe("<UnitDetails />", () => {
     expect(screen.getByText("Vapaa")).toBeInTheDocument();
     expect(screen.getByText("Koiralatu")).toBeInTheDocument();
   });
+
+  describe("elevation stats", () => {
+    const geometry_3d = {
+      type: "MultiLineString",
+      coordinates: [
+        [
+          [24.9, 60.1, 10],
+          [24.91, 60.11, 25],
+        ],
+        [
+          [24.92, 60.12, 5],
+          [24.93, 60.13, 40],
+        ],
+      ],
+    };
+
+    it("should display highest and lowest elevation when geometry_3d is available", () => {
+      renderComponent({}, { geometry_3d });
+
+      const highestPoint = screen.getByText("Korkein kohta:");
+      expect(highestPoint).toBeInTheDocument();
+      expect(within(highestPoint).getByText("40.0m")).toBeInTheDocument();
+      const lowestPoint = screen.getByText("Matalin kohta:");
+      expect(lowestPoint).toBeInTheDocument();
+      expect(within(lowestPoint).getByText("5.0m")).toBeInTheDocument();
+    });
+
+    it("should not display elevation stats when geometry_3d is absent", () => {
+      renderComponent({}, { geometry_3d: undefined });
+
+      expect(screen.queryByText("Korkein kohta:")).not.toBeInTheDocument();
+      expect(screen.queryByText("Matalin kohta:")).not.toBeInTheDocument();
+    });
+
+    it("should not display elevation stats when geometry_3d has no z-coordinates", () => {
+      renderComponent({}, {
+        geometry_3d: {
+          type: "MultiLineString",
+          coordinates: [[[24.9, 60.1], [24.91, 60.11]]],
+        },
+      });
+
+      expect(screen.queryByText("Korkein kohta:")).not.toBeInTheDocument();
+      expect(screen.queryByText("Matalin kohta:")).not.toBeInTheDocument();
+    });
+  });
 });
 
 it("should render 'Lisää suosikiksi' button", () => {

--- a/src/domain/unit/unitHelpers.ts
+++ b/src/domain/unit/unitHelpers.ts
@@ -720,3 +720,46 @@ export const getDefaultUnitObservation = (unit: Unit) => {
   };
   return observation;
 };
+
+export const calculateElevationStats = (
+  geometry_3d: Unit["geometry_3d"],
+): { highest: number; lowest: number } | null => {
+  if (!geometry_3d) return null;
+  const allElevations = geometry_3d.coordinates
+    .flat()
+    .map((pos) => pos[2])
+    .filter((e): e is number => e !== undefined && !isNaN(e));
+  if (allElevations.length === 0) return null;
+  return {
+    highest: Math.max(...allElevations),
+    lowest: Math.min(...allElevations),
+  };
+};
+
+export const getUnitObservations = (unit: Unit | undefined) => {
+  if (!unit || !has(unit, "observations")) {
+    return {
+      temperatureObservation: null,
+      liveTemperatureObservation: null,
+      liveWaterQualityObservation: null,
+    };
+  }
+  return {
+    temperatureObservation: getObservation(unit, "swimming_water_temperature"),
+    liveTemperatureObservation: getObservation(unit, "live_swimming_water_temperature"),
+    liveWaterQualityObservation: getObservation(unit, "live_swimming_water_quality"),
+  };
+};
+
+export const isUnitInFavourites = (unit: Unit): boolean => {
+  const favourites = JSON.parse(localStorage.getItem("favouriteUnits") ?? "[]") as Unit[];
+  return favourites.some((favourite) => favourite.id === unit.id);
+};
+
+export const toggleFavourite = (unit: Unit): void => {
+  const favourites = JSON.parse(localStorage.getItem("favouriteUnits") ?? "[]") as Unit[];
+  const updated = favourites.some((f) => f.id === unit.id)
+    ? favourites.filter((f) => f.id !== unit.id)
+    : [...favourites, unit];
+  localStorage.setItem("favouriteUnits", JSON.stringify(updated));
+};


### PR DESCRIPTION
## Description

This PR addresses accessibility issues with the height profile component and adds elevation statistics display to unit details. The changes focus on:

1. **Accessibility Improvement**: Hide the height profile control from screen readers using `aria-hidden="true"` since it's not fully accessible to assistive device users.
2. **Elevation Statistics**: Display the highest and lowest elevation points for units with 3D geometry data.
3. **Code Refactoring**: Extract helper functions from `UnitDetails.tsx` to `unitHelpers.ts` for better code organization and reusability.

## Context

The height profile visualization is not fully accessible, and rather than complex retrofitting, we hide it from screen reader users since the height profile is primarily a visual enhancement. Additionally, users requested visibility into elevation statistics for trails and routes.

[HUL-62](https://andersinno.atlassian.net/browse/HUL-62)

## How Has This Been Tested?

- Unit tests added for elevation statistics calculation with various geometry scenarios
- Manual testing with screen readers (NVDA/JAWS/VoiceOver/Orca) to verify height profile control is hidden
- Visual verification that height profile still renders correctly for sighted users
- Tests for elevation display with and without 3D geometry data

## Manual Testing Instructions for Reviewers

1. **Test Elevation Statistics Display:**
   - Navigate to a unit with 3D geometry (e.g., ski trails, cycling routes)
   - Verify "Highest point" and "Lowest point" values are displayed in the location info section
   - Confirm values are calculated correctly from the 3D geometry data
   - Test with a unit without 3D geometry to ensure stats don't appear

2. **Test Height Profile Accessibility:**
   - Open a unit detail page with height profile data
   - Use a screen reader to navigate the page
   - Verify the height profile control is NOT announced or navigable
   - Confirm other content is still accessible to screen readers

3. **Visual Verification:**
   - Verify height profile chart displays correctly
   - Ensure elevation stats are displayed with correct formatting
   - Test on mobile and desktop views

## Changes

- **src/domain/i18n/locales/en.json** - Added translation keys `HIGHEST_POINT` and `LOWEST_POINT`
- **src/domain/i18n/locales/fi.json** - Added Finnish translations for elevation stats
- **src/domain/i18n/locales/sv.json** - Added Swedish translations for elevation stats
- **src/domain/map/HeightProfileControl.ts** - Added `aria-hidden="true"` attribute to control container to hide from screen readers (2 lines added)
- **src/domain/unit/details/UnitDetails.tsx** - Removed helper functions (moved to unitHelpers.ts), added elevation stats display logic using `calculateElevationStats`, imported helper functions from unitHelpers
- **src/domain/unit/details/__tests__/UnitDetails.test.tsx** - Added 3 new test cases for elevation statistics:
  - Display elevation stats when 3D geometry is available
  - No display when geometry_3d is absent
  - No display when geometry_3d has no z-coordinates
- **src/domain/unit/unitHelpers.ts** - Added 4 new exported functions:
  - `calculateElevationStats()` - Extracts highest and lowest elevation from 3D geometry
  - `getUnitObservations()` - Helper to extract observations (moved from UnitDetails)
  - `isUnitInFavourites()` - Check if unit is in favorites (moved from UnitDetails)
  - `toggleFavourite()` - Add/remove unit from favorites (moved and refactored from UnitDetails)

## Screenshots


https://github.com/user-attachments/assets/1126687d-6c9a-4be8-b707-7441a6e25bce


