### PR TITLE
HUL-65 move focus to search results heading after search

### DIFF
--- a/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
+++ b/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonVariant, IconArrowRight } from "hds-react";
 import L from "leaflet";
 import values from "lodash/values";
-import React, { RefObject, useCallback } from "react";
+import React, { RefObject, useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
 
@@ -72,14 +72,25 @@ type Props = {
 
 function UnitBrowserResultList({ leafletMap }: Props) {
   const { t } = useTranslation();
-  const { sortKey, maxUnitCount } = useAppSearch();
+  const { q, sortKey, maxUnitCount } = useAppSearch();
   const doSearch = useDoSearch();
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const prevResultsNullRef = useRef(true);
 
   const { totalUnits, results } = useUnitSearchResults({
     sortKey,
     maxUnitCount: Number(maxUnitCount),
     leafletMap,
   });
+
+  useEffect(() => {
+    const wasLoading = prevResultsNullRef.current;
+    prevResultsNullRef.current = results === null;
+
+    if (wasLoading && results !== null && q) {
+      headingRef.current?.focus();
+    }
+  }, [results, q]);
 
   const handleOnSortKeySelect = useCallback(
     (nextSortKey: string | null) => {
@@ -108,6 +119,13 @@ function UnitBrowserResultList({ leafletMap }: Props) {
   return (
     <View id="list-view" className="list-view">
       <div className="list-view__container">
+        <h2
+          ref={headingRef}
+          className="list-view__results-heading"
+          tabIndex={-1}
+        >
+          {t("APP.SEARCH_RESULTS_PANEL")}
+        </h2>
         <div className="list-view__block">
           <UnitBrowserResultListSort
             values={values(SortKeys)}

--- a/src/domain/unit/browser/resultList/_unitBrowserResultList.scss
+++ b/src/domain/unit/browser/resultList/_unitBrowserResultList.scss
@@ -4,6 +4,18 @@
   .list-view__container {
     margin: 0;
 
+    .list-view__results-heading {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
     .list-view__block {
       border-top: 1px solid $ui-content;
       padding: $gap 0;


### PR DESCRIPTION
## Description

Implement WCAG 2.4.3 compliance by moving focus to search results after search completion.

## Context

When users submit a search, focus remains on the search input. Assistive technology users cannot perceive that the search has completed, making it difficult to navigate results. This change moves focus to a landmark heading at the top of results, allowing AT users to immediately know the search succeeded and where to begin reading.


[HUL-65](https://andersinno.atlassian.net/browse/HUL-65)

## Changes

-   `UnitBrowserResultList.tsx` — Added focus management: `headingRef, prevResultsNullRef, useEffect ` hook to detect search completion and programmatically focus results heading. Destructured `q ` from `useAppSearch()` and added `visually-hidden <h2> ` results heading.

  

-   `_unitBrowserResultList.scss` — Added` .list-view__results-heading`  sr-only styling (clip technique) to hide heading from sighted users while keeping it accessible to screen readers.

## How Has This Been Tested?

- Keyboard + DevTools: After search submit, `document.activeElement `returns the `<h2 class="list-view__results-heading"> ` element, confirming focus moved.

- Screen reader (manual): Focus movement is announced by Orca/NVDA/VoiceOver as "Search results, heading level 2"

- No breaking changes: Existing functionality and tab order unaffected; heading is not in keyboard tab order `(tabIndex={-1})`

## Manual Testing Instructions for Reviewers

1. Screen reader test (VoiceOver/NVDA/Orca):

    -  Enable screen reader
    -  Navigate to search field (Tab)   
    -  Type a search term and press Enter  
    -  Screen reader should announce "Search results, heading level 2" (or localized equivalent)

2. DevTools keyboard test:

    -  Open DevTools Console
    -  Type a search term and press Enter (results load)
    -  Run: `document.activeElement.className` → should return `list-view__results-heading`

3. Visual verification:

    -  Confirm heading is NOT visible to sighted users (should be hidden off-screen via CSS)
    -  Tab through results — heading should never appear in tab order

## Screenshots


https://github.com/user-attachments/assets/c45eb3e2-f161-4da1-b4a0-28f93c0ef95d
