### PR TITLE
fix(search): implement WCAG 4.1.2 combobox ARIA pattern for search field

### DIFF
--- a/src/domain/search/SearchBar.tsx
+++ b/src/domain/search/SearchBar.tsx
@@ -12,6 +12,9 @@ type Props = {
   inputRef?: RefObject<HTMLInputElement>;
   searchActive: boolean;
   disabled: boolean;
+  ariaExpanded: boolean;
+  ariaControls: string;
+  ariaActiveDescendant?: string;
 };
 
 function SearchBar({
@@ -24,6 +27,9 @@ function SearchBar({
   inputRef,
   searchActive,
   disabled,
+  ariaExpanded,
+  ariaControls,
+  ariaActiveDescendant,
 }: Props) {
   const { t } = useTranslation();
   const loaddingText = t("GENERAL.LOADING");
@@ -53,7 +59,13 @@ function SearchBar({
           ref={inputRef}
           name="search"
           id="search"
+          role="combobox"
           aria-label={t("SEARCH.SEARCH")}
+          aria-expanded={ariaExpanded}
+          aria-controls={ariaControls}
+          aria-autocomplete="list"
+          aria-haspopup="listbox"
+          aria-activedescendant={ariaActiveDescendant}
           type="text"
           onChange={(e) => onInput(e.target.value)}
           onFocus={onFocus}

--- a/src/domain/search/SearchContainer.tsx
+++ b/src/domain/search/SearchContainer.tsx
@@ -1,7 +1,12 @@
 import { useState, useCallback, useEffect, useRef } from "react";
+import { useHistory } from "react-router-dom";
 
 import SearchBar from "./SearchBar";
 import SearchSuggestions, { Suggestion } from "./SearchSuggestions";
+import useLanguage from "../../common/hooks/useLanguage";
+import * as PathUtils from "../../common/utils/pathUtils";
+
+const LISTBOX_ID = "search-suggestions-listbox";
 
 type Props = {
   search?: string;
@@ -27,10 +32,13 @@ function SearchContainer({
   const [searchPhrase, setSearchPhrase] = useState(search);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [menuPosition, setMenuPosition] = useState({ top: 0 });
+  const [activeIndex, setActiveIndex] = useState(-1);
   const preventFocusOpen = useRef(false);
   const preventBlurClose = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const history = useHistory();
+  const language = useLanguage();
 
   useEffect(() => {
     setSearchPhrase(search);
@@ -68,7 +76,8 @@ function SearchContainer({
   const onInputChange = useCallback(
     (value: string): void => {
       setSearchPhrase(value);
-      
+      setActiveIndex(-1);
+
       // Only show suggestions if there's actual search text
       if (value && value.trim().length > 0) {
         setShowSuggestions(true);
@@ -85,11 +94,13 @@ function SearchContainer({
   const handleSearch = useCallback(() => {
     onSearch(searchPhrase);
     setShowSuggestions(false);
+    setActiveIndex(-1);
   }, [onSearch, searchPhrase]);
 
   const clear = useCallback(() => {
     setSearchPhrase("");
     setShowSuggestions(false);
+    setActiveIndex(-1);
     onClear();
   }, [onClear]);
 
@@ -97,6 +108,7 @@ function SearchContainer({
     (coordinates: [number, number]) => {
       setSearchPhrase("");
       setShowSuggestions(false);
+      setActiveIndex(-1);
       onClear();
       onAddressClick(coordinates);
     },
@@ -141,6 +153,7 @@ function SearchContainer({
     if (event.key === "Escape") {
       preventFocusOpen.current = true;
       setShowSuggestions(false);
+      setActiveIndex(-1);
 
       // Focus the search input after closing suggestions
       if (searchInputRef.current) {
@@ -151,17 +164,55 @@ function SearchContainer({
 
   const handleInputKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
         event.preventDefault();
         if (!showSuggestions && searchPhrase && searchPhrase.length > 0) {
           setShowSuggestions(true);
+          setActiveIndex(-1);
           onFindSuggestions(searchPhrase);
-          // Update position when opening suggestions
           setTimeout(updateMenuPosition, 0);
+          return;
+        }
+        if (showSuggestions && suggestions.length > 0) {
+          setActiveIndex((prev) => {
+            if (event.key === "ArrowDown") {
+              return Math.min(prev + 1, suggestions.length - 1);
+            }
+            return Math.max(prev - 1, -1);
+          });
+        }
+      } else if (event.key === "Tab") {
+        setShowSuggestions(false);
+        setActiveIndex(-1);
+      } else if (event.key === "Enter") {
+        if (activeIndex >= 0 && activeIndex < suggestions.length) {
+          event.preventDefault();
+          const suggestion = suggestions[activeIndex];
+          if (suggestion.coordinates) {
+            handleAddressClick(suggestion.coordinates);
+          } else if (suggestion.to) {
+            const to =
+              typeof suggestion.to === "string"
+                ? PathUtils.getPathnameWithLanguage(suggestion.to, language)
+                : suggestion.to;
+            history.push(to as string);
+            setShowSuggestions(false);
+            setActiveIndex(-1);
+          }
         }
       }
     },
-    [showSuggestions, searchPhrase, onFindSuggestions, updateMenuPosition],
+    [
+      showSuggestions,
+      searchPhrase,
+      suggestions,
+      activeIndex,
+      onFindSuggestions,
+      updateMenuPosition,
+      handleAddressClick,
+      history,
+      language,
+    ],
   );
 
   return (
@@ -182,6 +233,11 @@ function SearchContainer({
         inputRef={searchInputRef}
         searchActive={isActive}
         disabled={disabled}
+        ariaExpanded={showSuggestions}
+        ariaControls={LISTBOX_ID}
+        ariaActiveDescendant={
+          activeIndex >= 0 ? `search-suggestion-${activeIndex}` : undefined
+        }
       />
       {showSuggestions && searchPhrase && searchPhrase.trim().length > 0 && (
         <SearchSuggestions
@@ -190,6 +246,7 @@ function SearchContainer({
           handleAddressClick={handleAddressClick}
           menuPosition={menuPosition}
           preventBlurCloseRef={preventBlurClose}
+          activeIndex={activeIndex}
         />
       )}
     </div>

--- a/src/domain/search/SearchSuggestions.tsx
+++ b/src/domain/search/SearchSuggestions.tsx
@@ -1,6 +1,6 @@
 import { Button, ButtonSize, ButtonVariant, IconSearch } from "hds-react";
 import { LocationDescriptor } from "history";
-import { MutableRefObject } from "react";
+import { MutableRefObject, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import Link from "../../common/components/Link";
@@ -23,6 +23,7 @@ type Props = {
   suggestions: Suggestion[];
   menuPosition: { top: number };
   preventBlurCloseRef: MutableRefObject<boolean>;
+  activeIndex: number;
 };
 
 function SearchSuggestions({
@@ -31,13 +32,26 @@ function SearchSuggestions({
   suggestions,
   menuPosition,
   preventBlurCloseRef,
+  activeIndex,
 }: Props) {
   const { t } = useTranslation();
+  const listboxRef = useRef<HTMLUListElement>(null);
 
   const suggestionCount = suggestions.length;
   const searchableSuggestionCount = suggestions.filter(
     ({ type }) => type === "searchable",
   ).length;
+
+  useEffect(() => {
+  if (activeIndex < 0 || activeIndex >= suggestions.length) {
+    return;
+  }
+
+  const activeOption = listboxRef.current?.querySelector<HTMLElement>(
+    `#search-suggestion-${activeIndex}`,
+  );
+  activeOption?.scrollIntoView({ block: "nearest" });
+}, [activeIndex, suggestions.length]);
 
   return (
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
@@ -69,40 +83,50 @@ function SearchSuggestions({
               variant={ButtonVariant.Supplementary}
               iconEnd={<IconSearch />}
               size={ButtonSize.Small}
+              tabIndex={-1}
             >
               {t("SEARCH.SHOW_ALL_RESULTS")}
             </Button>
           )}
-          {suggestions.map(({ icon, label, to, coordinates, unit }) => (
-            <Link
-              key={label}
-              to={to || "#"}
-              onClick={(e) => {
-                if (coordinates) {
-                  e.preventDefault();
-                  handleAddressClick(coordinates);
-                }
-              }}
-              className="search-suggestions__result"
-            >
-              {unit && (
-                <div className="search-suggestions__result-icon">
-                  <UnitIcon unit={unit} />
-                </div>
-              )}
-              {icon && (
-                <div className="search-suggestions__result-icon">
-                  <img src={icon} height="21px" alt="" />
-                </div>
-              )}
-              <div className="search-suggestions__result-details">
-                <div className="search-suggestions__result-details__name">
-                  {label}
-                </div>
-                {unit && <ObservationStatus unit={unit} />}
-              </div>
-            </Link>
-          ))}
+          <ul ref={listboxRef} role="listbox" id="search-suggestions-listbox" className="search-suggestions__options">
+            {suggestions.map(({ icon, label, to, coordinates, unit }, index) => (
+              <li
+                key={label}
+                role="option"
+                id={`search-suggestion-${index}`}
+                aria-selected={index === activeIndex}
+              >
+                <Link
+                  to={to || "#"}
+                  onClick={(e) => {
+                    if (coordinates) {
+                      e.preventDefault();
+                      handleAddressClick(coordinates);
+                    }
+                  }}
+                  className="search-suggestions__result"
+                  tabIndex={-1}
+                >
+                  {unit && (
+                    <div className="search-suggestions__result-icon">
+                      <UnitIcon unit={unit} />
+                    </div>
+                  )}
+                  {icon && (
+                    <div className="search-suggestions__result-icon">
+                      <img src={icon} height="21px" alt="" />
+                    </div>
+                  )}
+                  <div className="search-suggestions__result-details">
+                    <div className="search-suggestions__result-details__name">
+                      {label}
+                    </div>
+                    {unit && <ObservationStatus unit={unit} />}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
         </div>
       ) : null}
     </div>

--- a/src/domain/search/__tests__/SearchBar.test.jsx
+++ b/src/domain/search/__tests__/SearchBar.test.jsx
@@ -13,8 +13,12 @@ describe("<SearchBar />", () => {
   it("should have an input for making a search", () => {
     const value = "Test value";
     const onInput = vi.fn();
-    renderComponent({ onInput });
-    const input = screen.getByRole("textbox", { name: "Etsi" });
+    renderComponent({
+      onInput,
+      ariaExpanded: false,
+      ariaControls: "search-suggestions-listbox",
+    });
+    const input = screen.getByRole("combobox", { name: "Etsi" });
 
     expect(input).toBeInTheDocument();
 
@@ -24,9 +28,58 @@ describe("<SearchBar />", () => {
     expect(onInput).toHaveBeenCalledWith(value);
   });
 
+  it("should have the correct ARIA combobox attributes", () => {
+    renderComponent({
+      ariaExpanded: false,
+      ariaControls: "search-suggestions-listbox",
+    });
+    const input = screen.getByRole("combobox", { name: "Etsi" });
+
+    expect(input).toHaveAttribute("role", "combobox");
+    expect(input).toHaveAttribute("aria-expanded", "false");
+    expect(input).toHaveAttribute("aria-controls", "search-suggestions-listbox");
+    expect(input).toHaveAttribute("aria-autocomplete", "list");
+    expect(input).toHaveAttribute("aria-haspopup", "listbox");
+  });
+
+  it("should reflect aria-expanded when suggestions are open", () => {
+    renderComponent({
+      ariaExpanded: true,
+      ariaControls: "search-suggestions-listbox",
+    });
+    const input = screen.getByRole("combobox", { name: "Etsi" });
+
+    expect(input).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("should set aria-activedescendant when an option is active", () => {
+    renderComponent({
+      ariaExpanded: true,
+      ariaControls: "search-suggestions-listbox",
+      ariaActiveDescendant: "search-suggestion-2",
+    });
+    const input = screen.getByRole("combobox", { name: "Etsi" });
+
+    expect(input).toHaveAttribute("aria-activedescendant", "search-suggestion-2");
+  });
+
+  it("should not set aria-activedescendant when no option is active", () => {
+    renderComponent({
+      ariaExpanded: false,
+      ariaControls: "search-suggestions-listbox",
+    });
+    const input = screen.getByRole("combobox", { name: "Etsi" });
+
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+  });
+
   it("should have a submit button", async () => {
     const onSubmit = vi.fn();
-    renderComponent({ onSubmit });
+    renderComponent({
+      onSubmit,
+      ariaExpanded: false,
+      ariaControls: "search-suggestions-listbox",
+    });
     const submitButton = screen.getByRole("button", { name: "Etsi" });
 
     expect(submitButton).toBeTruthy();
@@ -40,6 +93,8 @@ describe("<SearchBar />", () => {
     renderComponent({
       input: "Search",
       searchActive: true,
+      ariaExpanded: false,
+      ariaControls: "search-suggestions-listbox",
     });
 
     expect(
@@ -50,6 +105,8 @@ describe("<SearchBar />", () => {
   it("should show a loading indicator when disabled is true", () => {
     renderComponent({
       disabled: true,
+      ariaExpanded: false,
+      ariaControls: "search-suggestions-listbox",
     });
 
     const loadingSpinnerStatus = screen.getByRole("status");

--- a/src/domain/search/__tests__/SearchContainer.test.tsx
+++ b/src/domain/search/__tests__/SearchContainer.test.tsx
@@ -13,18 +13,25 @@ vi.mock("../SearchBar", () => ({
     inputRef,
     searchActive,
     disabled,
+    ariaExpanded,
+    ariaControls,
+    ariaActiveDescendant,
   }: any) {
     return (
       <div data-testid="search-bar">
         <input
           ref={inputRef}
           data-testid="search-input"
+          role="combobox"
           value={input}
           onChange={(e) => onInput(e.target.value)}
           onFocus={onFocus}
           onKeyDown={onKeyDown}
           disabled={disabled}
           placeholder="Search..."
+          aria-expanded={ariaExpanded}
+          aria-controls={ariaControls}
+          aria-activedescendant={ariaActiveDescendant}
         />
         <button onClick={onSubmit} data-testid="search-submit">
           Search
@@ -519,6 +526,131 @@ describe("<SearchContainer />", () => {
 
       // The real SearchSuggestions component renders Link elements with the label text
       expectSuggestionsToBeVisible();
+    });
+  });
+
+  describe("combobox ARIA state", () => {
+    it("should set aria-expanded=false when suggestions are hidden", () => {
+      renderComponent();
+      const input = screen.getByTestId("search-input");
+      expect(input).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("should set aria-expanded=true when suggestions are shown", async () => {
+      renderComponent({ suggestions: mockSuggestions });
+      const input = screen.getByTestId("search-input");
+      await userEvent.type(input, "H");
+      await expectSuggestionsToAppear();
+      expect(input).toHaveAttribute("aria-expanded", "true");
+    });
+
+    it("should set aria-controls to the listbox id", () => {
+      renderComponent();
+      const input = screen.getByTestId("search-input");
+      expect(input).toHaveAttribute("aria-controls", "search-suggestions-listbox");
+    });
+
+    it("should not set aria-activedescendant when no option is active", async () => {
+      renderComponent({ suggestions: mockSuggestions });
+      const input = screen.getByTestId("search-input");
+      await userEvent.type(input, "H");
+      await expectSuggestionsToAppear();
+      // No arrow key pressed yet — no active option
+      expect(input).not.toHaveAttribute("aria-activedescendant");
+    });
+
+    it("should update aria-activedescendant when navigating with ArrowDown", async () => {
+      renderComponent({ suggestions: mockSuggestions });
+      const input = screen.getByTestId("search-input");
+
+      const user = userEvent.setup();
+      await user.type(input, "H");
+      await expectSuggestionsToAppear();
+
+      await user.keyboard("{ArrowDown}");
+      expect(input).toHaveAttribute("aria-activedescendant", "search-suggestion-0");
+
+      await user.keyboard("{ArrowDown}");
+      expect(input).toHaveAttribute("aria-activedescendant", "search-suggestion-1");
+    });
+
+    it("should update aria-activedescendant when navigating with ArrowUp", async () => {
+      renderComponent({ suggestions: mockSuggestions });
+      const input = screen.getByTestId("search-input");
+
+      const user = userEvent.setup();
+      await user.type(input, "H");
+      await expectSuggestionsToAppear();
+
+      // Go down to index 1, then up to index 0
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{ArrowUp}");
+      expect(input).toHaveAttribute("aria-activedescendant", "search-suggestion-0");
+    });
+
+    it("should clear aria-activedescendant when ArrowUp is pressed on the first option", async () => {
+      renderComponent({ suggestions: mockSuggestions });
+      const input = screen.getByTestId("search-input");
+
+      const user = userEvent.setup();
+      await user.type(input, "H");
+      await expectSuggestionsToAppear();
+
+      await user.keyboard("{ArrowDown}");
+      expect(input).toHaveAttribute("aria-activedescendant", "search-suggestion-0");
+
+      await user.keyboard("{ArrowUp}");
+      expect(input).not.toHaveAttribute("aria-activedescendant");
+    });
+
+    it("should select highlighted address suggestion on Enter", async () => {
+      const onAddressClick = vi.fn();
+      const onClear = vi.fn();
+      renderComponent({ suggestions: mockSuggestions, onAddressClick, onClear });
+      const input = screen.getByTestId("search-input");
+
+      const user = userEvent.setup();
+      await user.type(input, "H");
+      await expectSuggestionsToAppear();
+
+      // Highlight first suggestion (Helsinki with coordinates [1,2])
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{Enter}");
+
+      expect(onAddressClick).toHaveBeenCalledWith([1, 2]);
+      expectSuggestionsToBeHidden();
+    });
+
+    it("should reset activeIndex when suggestions are closed via Escape", async () => {
+      renderComponent({ suggestions: mockSuggestions });
+      const input = screen.getByTestId("search-input");
+
+      const user = userEvent.setup();
+      await user.type(input, "H");
+      await expectSuggestionsToAppear();
+
+      await user.keyboard("{ArrowDown}");
+      expect(input).toHaveAttribute("aria-activedescendant", "search-suggestion-0");
+
+      await user.keyboard("{Escape}");
+      expect(input).not.toHaveAttribute("aria-activedescendant");
+      expectSuggestionsToBeHidden();
+    });
+
+    it("should close suggestions and reset activeIndex on Tab", async () => {
+      renderComponent({ suggestions: mockSuggestions });
+      const input = screen.getByTestId("search-input");
+
+      const user = userEvent.setup();
+      await user.type(input, "H");
+      await expectSuggestionsToAppear();
+
+      await user.keyboard("{ArrowDown}");
+      await user.keyboard("{Tab}");
+
+      expectSuggestionsToBeHidden();
+      expect(input).not.toHaveAttribute("aria-activedescendant");
     });
   });
 });

--- a/src/domain/search/__tests__/SearchSuggestions.test.tsx
+++ b/src/domain/search/__tests__/SearchSuggestions.test.tsx
@@ -23,7 +23,9 @@ const defaultProps = {
   handleAddressClick: vi.fn(),
   suggestions: [] as Suggestion[],
   menuPosition: { top: 100 },
-  preventBlurClose: mockPreventBlurClose,  preventBlurCloseRef: mockPreventBlurClose,};
+  preventBlurCloseRef: mockPreventBlurClose,
+  activeIndex: -1,
+};
 
 const mockUnit: Unit = {
   id: "123",
@@ -288,6 +290,64 @@ describe("<SearchSuggestions />", () => {
       expect(screen.getByText("Search 1")).toBeInTheDocument();
       expect(screen.getByText("Loose 1")).toBeInTheDocument();
       expect(screen.getByText("Search 2")).toBeInTheDocument();
+    });
+  });
+
+  describe("combobox ARIA roles", () => {
+    it("should render suggestions inside a listbox", () => {
+      renderComponent({ suggestions: mockSuggestions.slice(0, 2) });
+
+      const listbox = screen.getByRole("listbox");
+      expect(listbox).toBeInTheDocument();
+      expect(listbox).toHaveAttribute("id", "search-suggestions-listbox");
+    });
+
+    it("should render each suggestion as an option", () => {
+      renderComponent({ suggestions: mockSuggestions.slice(0, 2) });
+
+      const options = screen.getAllByRole("option");
+      expect(options).toHaveLength(2);
+    });
+
+    it("should set aria-selected=false on all options when activeIndex is -1", () => {
+      renderComponent({ suggestions: mockSuggestions.slice(0, 2), activeIndex: -1 });
+
+      const options = screen.getAllByRole("option");
+      options.forEach((opt) => {
+        expect(opt).toHaveAttribute("aria-selected", "false");
+      });
+    });
+
+    it("should set aria-selected=true on the active option", () => {
+      renderComponent({ suggestions: mockSuggestions.slice(0, 3), activeIndex: 1 });
+
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("aria-selected", "false");
+      expect(options[1]).toHaveAttribute("aria-selected", "true");
+      expect(options[2]).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("should assign unique ids to each option", () => {
+      renderComponent({ suggestions: mockSuggestions.slice(0, 3) });
+
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveAttribute("id", "search-suggestion-0");
+      expect(options[1]).toHaveAttribute("id", "search-suggestion-1");
+      expect(options[2]).toHaveAttribute("id", "search-suggestion-2");
+    });
+
+    it("should render suggestion links with tabIndex -1", () => {
+      renderComponent({ suggestions: mockSuggestions.slice(0, 1) });
+
+      const link = screen.getByRole("link", { name: /Helsinki/i });
+      expect(link).toHaveAttribute("tabindex", "-1");
+    });
+
+    it("should render 'show all results' button with tabIndex -1", () => {
+      renderComponent({ suggestions: mockSuggestions.slice(0, 1) });
+
+      const button = screen.getByRole("button", { name: "Näytä kaikki hakutulokset" });
+      expect(button).toHaveAttribute("tabindex", "-1");
     });
   });
 });

--- a/src/domain/search/_searchSuggestions.scss
+++ b/src/domain/search/_searchSuggestions.scss
@@ -27,6 +27,16 @@
     }
   }
 
+  &__options {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    li[aria-selected="true"] .search-suggestions__result {
+      background-color: $list-view-item-hover;
+    }
+  }
+
   &__result {
     cursor: pointer;
     padding: $gap;

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -39,6 +39,9 @@ const localStorageMock = {
 
 globalThis.localStorage ??= Object.create(localStorageMock);
 
+// jsdom does not implement scrollIntoView
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
 // Mock ResizeObserver
 globalThis.ResizeObserver = class ResizeObserver {
   constructor() {} // NOSONAR - Empty constructor required for ResizeObserver mock


### PR DESCRIPTION
## Description

Implements the WAI-ARIA combobox pattern on the search field to fix WCAG 4.1.2 (Name, Role, Value) non-conformance.

The search input now has `role="combobox"` with `aria-expanded`, `aria-controls`, `aria-autocomplete`, `aria-haspopup`, and `aria-activedescendant`. The suggestion dropdown has `role="listbox"` and each suggestion item has `role="option"` with a unique `id` and `aria-selected`. Arrow key navigation moves `aria-activedescendant` through the options without removing DOM focus from the input. Enter selects the highlighted option, Tab closes the popup, and Escape closes it and returns focus to the input. Suggestion links and the "Show all results" button are excluded from the Tab sequence (`tabIndex=-1`) as required by the pattern.

## Context

The search field visually resembles a combobox but was technically a plain `<input type="text">`. Assistive technologies therefore announced it as a regular text field, giving screen reader users no information about the presence of suggestions. It was also impossible to navigate suggestions using the standard screen reader combobox interaction (arrow keys).

This change makes the component conform to the [WAI-ARIA combobox + listbox popup pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/).

[HUL-66](https://andersinno.atlassian.net/browse/HUL-66)

**Changes:**
- `SearchBar.tsx`: add `role="combobox"`, `aria-expanded`, `aria-controls`, `aria-autocomplete="list"`, `aria-haspopup="listbox"`, and `aria-activedescendant` to the search input
- `SearchSuggestions.tsx`: wrap suggestions in `role="listbox"`; each suggestion gets `role="option"`, a unique `id`, and `aria-selected`; move "Show all results" button outside the listbox; add `tabIndex=-1` to suggestion links and the button
- `SearchContainer.tsx`: add `activeIndex` state; implement ArrowDown/Up navigation, Enter to select, Tab and Escape to close; pass new ARIA props down to SearchBar and SearchSuggestions
- `_searchSuggestions.scss`: add `li[aria-selected="true"]` rule to visually highlight the keyboard-active suggestion
- `SearchBar.test.jsx`: update role query from `textbox` to `combobox`; add assertions for all new ARIA attributes
- `SearchSuggestions.test.tsx`: add assertions for `role="listbox"`, `role="option"`, `aria-selected`, `tabIndex=-1`
- `SearchContainer.test.tsx`: update SearchBar mock to forward new ARIA props; add tests for `aria-expanded`, `aria-activedescendant` updates, Enter selection, Escape and Tab closing behaviour

## How Has This Been Tested?

- Existing unit tests updated to reflect new ARIA roles (`role="combobox"` on input, `role="listbox"` on dropdown, `role="option"` on each suggestion)
- New unit tests added covering: `aria-expanded` toggling, `aria-activedescendant` updates on ArrowDown/ArrowUp, clearing `aria-activedescendant` when ArrowUp reaches the top, Enter selecting the highlighted suggestion, Escape and Tab closing the popup and resetting the active index

## Manual Testing Instructions for Reviewers

1. **Mouse / basic smoke test** — click the search field, type a word (e.g. `Kallio`). Suggestions should appear and be clickable as before.

2. **Keyboard navigation**
   - Tab to the search field, type a word
   - Press **ArrowDown** — the first suggestion gets a visual background highlight
   - Press **ArrowDown** again — highlight moves to the next suggestion
   - Press **ArrowUp** — highlight moves back up; pressing ArrowUp on the first item removes the highlight entirely
   - Press **Enter** on a highlighted suggestion — it navigates/selects and the dropdown closes
   - Re-open suggestions, then press **Escape** — dropdown closes, focus remains in the input
   - Re-open suggestions, then press **Tab** — dropdown closes, focus moves to the next focusable element on the page

3. **Accessibility tree (DevTools)**
   - Open browser DevTools → Accessibility panel, inspect the search input
   - It should show `role: combobox`, `aria-expanded: false` at rest
   - While typing, `aria-expanded` should flip to `true`
   - While navigating with arrow keys, `aria-activedescendant` should update to `search-suggestion-{n}`

4. **Screen reader (optional but recommended)**
   - With (NVDA, VoiceOver or Orca), focus the input — it should be announced as *"Search, combobox, collapsed"* (or equivalent)
   - After typing, pressing ArrowDown should cause the screen reader to read the label of the first suggestion

## Screenshots


https://github.com/user-attachments/assets/0e270c55-7439-4290-82bf-270e3a5e292b


