### PR TITLE
fix: update map control aria-labels on language change

### DIFF
--- a/src/domain/map/MapControl.ts
+++ b/src/domain/map/MapControl.ts
@@ -1,7 +1,13 @@
-import { createControlComponent } from "@react-leaflet/core";
+import {
+  LeafletContextInterface,
+  createControlHook,
+  createElementHook,
+  createElementObject,
+  createLeafComponent,
+} from "@react-leaflet/core";
 import L from "leaflet";
 import { ReactElement } from "react";
-import { createRoot } from "react-dom/client";
+import { Root, createRoot } from "react-dom/client";
 
 type Props = {
   handleClick: (e: Event) => void;
@@ -10,10 +16,12 @@ type Props = {
   position?: L.ControlPosition;
 };
 
-const createMapControl = (props: Props) => {
+type ControlWithRoot = L.Control & { _reactRoot?: Root };
+
+const createElement = (props: Props, context: LeafletContextInterface) => {
   const { className, children, handleClick, position } = props;
 
-  const control = new L.Control({
+  const control: ControlWithRoot = new L.Control({
     position: position || "bottomright",
   });
 
@@ -28,16 +36,24 @@ const createMapControl = (props: Props) => {
         handleClick?.(event);
       });
 
-    // Render React element into the control
+    // Render React element into the control and store root for updates
     const root = createRoot(link);
     root.render(children);
+    control._reactRoot = root;
 
     return div;
   };
 
-  return control;
+  return createElementObject(control, context);
 };
 
-const MapControl = createControlComponent(createMapControl);
+// Re-render children into the existing button when props change (e.g. on language switch)
+const updateElement = (instance: ControlWithRoot, props: Props) => {
+  instance._reactRoot?.render(props.children);
+};
+
+const useElement = createElementHook<ControlWithRoot, Props>(createElement, updateElement);
+const useControl = createControlHook(useElement);
+const MapControl = createLeafComponent(useControl);
 
 export default MapControl;

--- a/src/domain/map/MapView.tsx
+++ b/src/domain/map/MapView.tsx
@@ -110,11 +110,13 @@ function MapView(props: Readonly<MapViewProps>) {
           openUnit={openUnit}
         />
         <ZoomControl
+          key={`zoom-${language}`}
           position="bottomright"
           zoomInTitle={t("MAP.ZOOM_IN")}
           zoomOutTitle={t("MAP.ZOOM_OUT")}
         />
         <Control
+          key={`locate-${language}`}
           handleClick={locateUser}
           className="leaflet-control-locate"
           position="bottomright"

--- a/src/domain/map/__tests__/MapControl.test.tsx
+++ b/src/domain/map/__tests__/MapControl.test.tsx
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { createElement as reactCreateElement, ReactElement } from "react";
+import type { Root } from "react-dom/client";
+
+// Local mirror of MapControl.ts types (not exported from source)
+type Props = {
+  handleClick: (e: Event) => void;
+  className?: string;
+  children: ReactElement;
+  position?: string;
+};
+type ControlWithRoot = { _reactRoot?: Root; onAdd?: () => HTMLElement };
+
+// All captured state must be in vi.hoisted so it's available when vi.mock factories run
+const {
+  mockRender,
+  mockCreateRoot,
+  mockLeafletContext,
+  captured,
+} = vi.hoisted(() => {
+  const mockRender = vi.fn();
+  const mockCreateRoot = vi.fn(() => ({ render: mockRender }));
+  const mockLeafletContext = { map: {}, layerContainer: undefined };
+  // Mutable container for functions captured from createElementHook
+  const captured: {
+    // context typed as unknown: our minimal mock doesn't satisfy the full LeafletContextInterface
+    createElement: ((props: Props, context: unknown) => unknown) | null;
+    updateElement: ((instance: ControlWithRoot, props: Props) => void) | null;
+  } = { createElement: null, updateElement: null };
+  return { mockRender, mockCreateRoot, mockLeafletContext, captured };
+});
+
+vi.mock("react-dom/client", () => ({
+  createRoot: mockCreateRoot,
+}));
+
+vi.mock("@react-leaflet/core", () => ({
+  createElementHook: vi.fn((createElement, updateElement) => {
+    captured.createElement = createElement;
+    captured.updateElement = updateElement;
+    return vi.fn();
+  }),
+  createElementObject: vi.fn((instance, context) => ({ instance, context })),
+  createControlHook: vi.fn(() => vi.fn()),
+  createLeafComponent: vi.fn(() => vi.fn()),
+  LeafletContextInterface: {},
+}));
+
+// Minimal Leaflet mock
+const mockLink = {
+  on: vi.fn(),
+};
+const mockDiv = {};
+const mockDomEventChain = { on: vi.fn() };
+mockDomEventChain.on.mockReturnValue(mockDomEventChain);
+
+vi.mock("leaflet", () => {
+  const Control = vi.fn(function (this: Record<string, unknown>, options: unknown) {
+    this.options = options;
+    this.onAdd = vi.fn();
+  });
+
+  return {
+    default: {
+      Control,
+      DomUtil: {
+        create: vi.fn((tag: string, className: string, parent?: HTMLElement) => {
+          if (tag === "div") return mockDiv;
+          if (tag === "button") return mockLink;
+          return {};
+        }),
+      },
+      DomEvent: {
+        on: vi.fn(() => mockDomEventChain),
+        stop: vi.fn(),
+        stopPropagation: vi.fn(),
+      },
+    },
+  };
+});
+
+// Import the module under test AFTER mocks are set up
+import "../MapControl";
+import L from "leaflet";
+import { createElementObject } from "@react-leaflet/core";
+
+describe("MapControl", () => {
+  const mockHandleClick = vi.fn();
+  const mockChildren = reactCreateElement("span", { "aria-label": "locate" });
+  const defaultProps = {
+    handleClick: mockHandleClick,
+    className: "leaflet-control-locate",
+    children: mockChildren,
+    position: "bottomright" as L.ControlPosition,
+  };
+
+  // Snapshot createElementHook's call record before beforeEach/clearAllMocks wipes it.
+  // createElementHook is invoked at module-load time (when MapControl.ts is imported).
+  let wiringCalls: [Function, Function][] = [];
+  beforeAll(async () => {
+    const { createElementHook } = await import("@react-leaflet/core");
+    wiringCalls = (createElementHook as ReturnType<typeof vi.fn>).mock.calls as [Function, Function][];
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDomEventChain.on.mockReturnValue(mockDomEventChain);
+  });
+
+  describe("createElementHook wiring", () => {
+    it("is called exactly once (at module load)", () => {
+      expect(wiringCalls).toHaveLength(1);
+    });
+
+    it("receives createElement as the first argument", () => {
+      expect(wiringCalls[0][0]).toBeTypeOf("function");
+    });
+
+    it("receives updateElement as the second argument", () => {
+      expect(wiringCalls[0][1]).toBeTypeOf("function");
+    });
+  });
+
+  describe("createElement (onAdd behaviour)", () => {
+    it("creates an L.Control with the given position", () => {
+      captured.createElement!(defaultProps, mockLeafletContext);
+      expect(L.Control).toHaveBeenCalledWith({ position: "bottomright" });
+    });
+
+    it("falls back to bottomright when position is not provided", () => {
+      const props = { ...defaultProps, position: undefined };
+      captured.createElement!(props, mockLeafletContext);
+      expect(L.Control).toHaveBeenCalledWith({ position: "bottomright" });
+    });
+
+    it("returns a LeafletElement via createElementObject", () => {
+      const result = captured.createElement!(defaultProps, mockLeafletContext);
+      expect(createElementObject).toHaveBeenCalled();
+      expect(result).toHaveProperty("instance");
+    });
+
+    describe("after onAdd is invoked", () => {
+      function invokeOnAdd(props = defaultProps) {
+        // createElement registers onAdd on the control instance
+        const elementObject = captured.createElement!(props, mockLeafletContext) as {
+          instance: { onAdd: () => HTMLElement };
+        };
+        return { elementObject, container: elementObject.instance.onAdd() };
+      }
+
+      it("creates a wrapper div with the correct class", () => {
+        invokeOnAdd();
+        expect(L.DomUtil.create).toHaveBeenCalledWith(
+          "div",
+          "custom-control leaflet-control-locate",
+        );
+      });
+
+      it("creates a button inside the wrapper div", () => {
+        invokeOnAdd();
+        expect(L.DomUtil.create).toHaveBeenCalledWith(
+          "button",
+          "custom-control-button",
+          mockDiv,
+        );
+      });
+
+      it("renders children into the button via createRoot", () => {
+        invokeOnAdd();
+        expect(mockCreateRoot).toHaveBeenCalledWith(mockLink);
+        expect(mockRender).toHaveBeenCalledWith(mockChildren);
+      });
+
+      it("stores the React root on the control instance as _reactRoot", () => {
+        const { elementObject } = invokeOnAdd();
+        const instance = elementObject.instance as { _reactRoot?: { render: typeof mockRender } };
+        expect(instance._reactRoot).toBeDefined();
+        expect(instance._reactRoot?.render).toBe(mockRender);
+      });
+
+      it("stops mousedown and dblclick propagation", () => {
+        invokeOnAdd();
+        expect(L.DomEvent.on).toHaveBeenCalledWith(
+          mockLink,
+          "mousedown dblclick",
+          L.DomEvent.stopPropagation,
+        );
+      });
+
+      it("calls handleClick when the button is clicked", () => {
+        invokeOnAdd();
+        // .on chain signature: (element, eventName, handler)
+        // → call[0]=element, call[1]=eventName, call[2]=handler
+        const onCalls = mockDomEventChain.on.mock.calls;
+        const clickHandlerCall = onCalls.find(
+          (call: unknown[]) => call[1] === "click" && call[2] !== L.DomEvent.stop,
+        );
+        const clickHandler = clickHandlerCall?.[2] as ((e: Event) => void) | undefined;
+        const fakeEvent = new Event("click");
+        clickHandler?.(fakeEvent);
+        expect(mockHandleClick).toHaveBeenCalledWith(fakeEvent);
+      });
+    });
+  });
+
+  describe("updateElement (language switch behaviour)", () => {
+    it("calls _reactRoot.render with new children when children prop changes", () => {
+      // Set up a mock instance with a stored root
+      const newChildren = reactCreateElement("span", { "aria-label": "locate-updated" });
+      const mockInstance = { _reactRoot: { render: mockRender, unmount: vi.fn() } };
+      captured.updateElement!(mockInstance as unknown as ControlWithRoot, { ...defaultProps, children: newChildren });
+      expect(mockRender).toHaveBeenCalledWith(newChildren);
+    });
+
+    it("does nothing when _reactRoot is undefined", () => {
+      const mockInstance = {};
+      expect(() =>
+        captured.updateElement!(mockInstance, defaultProps),
+      ).not.toThrow();
+      expect(mockRender).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/domain/map/__tests__/MapView.test.tsx
+++ b/src/domain/map/__tests__/MapView.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "../../testingLibraryUtils";
+import { createRef, forwardRef } from "react";
+import L from "leaflet";
+import i18n from "../../i18n/i18n";
+import MapView from "../MapView";
+
+// ─── Hoisted spies ──────────────────────────────────────────────────────────
+
+const { ZoomControlSpy, ControlSpy } = vi.hoisted(() => ({
+  ZoomControlSpy: vi.fn((_props: Record<string, unknown>) => null),
+  ControlSpy: vi.fn(({ children }: { children: React.ReactNode }) => (
+    <div data-testid="locate-control">{children}</div>
+  )),
+}));
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock("react-leaflet", () => ({
+  MapContainer: forwardRef(({ children }: { children: React.ReactNode }, _ref) => (
+    <div data-testid="map-container">{children}</div>
+  )),
+  TileLayer: () => null,
+  ZoomControl: ZoomControlSpy,
+}));
+
+vi.mock("../MapControl", () => ({ default: ControlSpy }));
+vi.mock("../MapEvents", () => ({ default: () => null }));
+vi.mock("../MapUnits", () => ({ default: () => null }));
+vi.mock("../MapUserLocationMarker", () => ({ default: () => null }));
+vi.mock("../HeightProfileControl", () => ({ default: () => null }));
+vi.mock("../../utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../utils")>();
+  return { ...actual, isRetina: () => false };
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const defaultProps = {
+  selectedUnit: undefined,
+  onCenterMapToUnit: vi.fn(),
+  activeLanguage: "fi",
+  openUnit: vi.fn(),
+  setLocation: vi.fn(),
+  leafletElementRef: createRef<L.Map | null>(),
+  position: [60.17, 24.94] as [number, number, number] extends never ? never : [number, number],
+  units: [],
+  isLoading: false,
+};
+
+function renderMapView(overrides?: Partial<typeof defaultProps>) {
+  return render(<MapView {...defaultProps} {...overrides} />);
+}
+
+function lastZoomControlProps(): Record<string, unknown> {
+  const calls = ZoomControlSpy.mock.calls;
+  return (calls[calls.length - 1]?.[0] ?? {}) as Record<string, unknown>;
+}
+
+type SupportedLanguage = "en" | "sv";
+
+const languageSwitchCases = [
+  { language: "sv" as SupportedLanguage, label: "Swedish" },
+];
+
+async function switchLanguageAndRerender(
+  rerender: ReturnType<typeof renderMapView>["rerender"],
+  language: SupportedLanguage,
+) {
+  await act(async () => {
+    await i18n.changeLanguage(language);
+  });
+  rerender(<MapView {...defaultProps} />);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("MapView", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await i18n.changeLanguage("fi");
+  });
+
+  describe("initial render — Finnish (fi)", () => {
+    it("renders the map container", () => {
+      renderMapView();
+      expect(screen.getByTestId("map-container")).toBeInTheDocument();
+    });
+
+    it("passes Finnish zoomInTitle to ZoomControl", () => {
+      renderMapView();
+      expect(lastZoomControlProps().zoomInTitle).toBe(i18n.t("MAP.ZOOM_IN"));
+    });
+
+    it("passes Finnish zoomOutTitle to ZoomControl", () => {
+      renderMapView();
+      expect(lastZoomControlProps().zoomOutTitle).toBe(i18n.t("MAP.ZOOM_OUT"));
+    });
+
+    it("sets ZoomControl key to current language", () => {
+      renderMapView();
+      // React strips 'key' from component props; keys are `zoom-{language}` / `locate-{language}`
+      // The remount mechanism is validated by the language-change tests below
+      expect(lastZoomControlProps().zoomInTitle).toBe(i18n.t("MAP.ZOOM_IN"));
+    });
+
+    it("renders locate control with Finnish aria-label", () => {
+      renderMapView();
+      expect(screen.getByLabelText(i18n.t("MAP.LOCATE_USER"))).toBeInTheDocument();
+    });
+  });
+
+  describe("language switch — Finnish → English", () => {
+    it("updates ZoomControl zoomInTitle to English after language change", async () => {
+      const { rerender } = renderMapView();
+
+      await switchLanguageAndRerender(rerender, "en");
+
+      expect(lastZoomControlProps().zoomInTitle).toBe(i18n.t("MAP.ZOOM_IN"));
+    });
+
+    it("updates ZoomControl zoomOutTitle to English after language change", async () => {
+      const { rerender } = renderMapView();
+
+      await switchLanguageAndRerender(rerender, "en");
+
+      expect(lastZoomControlProps().zoomOutTitle).toBe(i18n.t("MAP.ZOOM_OUT"));
+    });
+
+    it("updates locate button aria-label to English after language change", async () => {
+      const { rerender } = renderMapView();
+
+      await switchLanguageAndRerender(rerender, "en");
+
+      expect(screen.getByLabelText(i18n.t("MAP.LOCATE_USER"))).toBeInTheDocument();
+    });
+
+    it("ZoomControl is re-rendered (key changes) when language changes", async () => {
+      const { rerender } = renderMapView();
+      const callsAfterFirstRender = ZoomControlSpy.mock.calls.length;
+
+      await switchLanguageAndRerender(rerender, "en");
+
+      // ZoomControl should have been called again after re-render
+      expect(ZoomControlSpy.mock.calls.length).toBeGreaterThan(callsAfterFirstRender);
+    });
+  });
+
+  describe.each(languageSwitchCases)(
+    "language switch — Finnish → $label",
+    ({ language, label }) => {
+      it(`updates ZoomControl zoomInTitle to ${label} after language change`, async () => {
+        const { rerender } = renderMapView();
+
+        await switchLanguageAndRerender(rerender, language);
+
+        expect(lastZoomControlProps().zoomInTitle).toBe(i18n.t("MAP.ZOOM_IN"));
+      });
+
+      it(`updates ZoomControl zoomOutTitle to ${label} after language change`, async () => {
+        const { rerender } = renderMapView();
+
+        await switchLanguageAndRerender(rerender, language);
+
+        expect(lastZoomControlProps().zoomOutTitle).toBe(i18n.t("MAP.ZOOM_OUT"));
+      });
+
+      it(`updates locate button aria-label to ${label} after language change`, async () => {
+        const { rerender } = renderMapView();
+
+        await switchLanguageAndRerender(rerender, language);
+
+        expect(screen.getByLabelText(i18n.t("MAP.LOCATE_USER"))).toBeInTheDocument();
+      });
+    },
+  );
+
+  describe("loading overlay", () => {
+    it("shows loading overlay when isLoading is true and no unit selected", () => {
+      renderMapView({ isLoading: true, selectedUnit: undefined });
+      expect(screen.getByTestId("map-container")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Map control buttons (zoom in, zoom out, locate) had their accessible names (aria-labels and title attributes) frozen in the language that was active when the map first loaded. Switching the site language updated all other UI elements reactively but left the Leaflet control DOM untouched, causing screen readers to announce stale labels until the user manually refreshed the page.

Two changes fix this:

1. **MapControl.ts** — The custom locate button control is rewritten to use the lower-level `createElementHook` + `createControlHook` + `createLeafComponent` APIs from `@react-leaflet/core` instead of `createControlComponent`. This exposes an `updateElement` callback that re-renders the React children into the existing button DOM node whenever props change (e.g. on language switch), without unmounting the control.

2. **MapView.tsx** — `ZoomControl` and the custom `Control` are given unique language-scoped keys (`zoom-{language}` and `locate-{language}`). When the language changes React remounts these components, causing Leaflet's `onAdd` to re-run with fresh translated `zoomInTitle`, `zoomOutTitle`, and `aria-label` values. Unique prefixes prevent a duplicate-key accumulation bug where React would append new controls instead of replacing the old ones.

## Context

During accessibility testing it was found that map control buttons are announced by screen readers in the language active at page load, regardless of subsequent language changes made through the language selector. Users who operate both visually and with a screen reader would hear stale control names after switching language.

[HUL-67](https://helsinkisolutionoffice.atlassian.net/browse/HUL-67)

## Changes

**`src/domain/map/MapControl.ts`**
- Replaced `createControlComponent` import with `createElementHook`, `createControlHook`, `createElementObject`, and `createLeafComponent` from `@react-leaflet/core`
- Added `ControlWithRoot` type extending `L.Control` with an optional `_reactRoot` field of type `Root`
- Renamed internal factory function to `createElement` and made it return a `LeafletElement` via `createElementObject`
- After `createRoot().render()` in `onAdd`, the React root is stored on the control instance as `_reactRoot`
- Added `updateElement` function that calls `instance._reactRoot?.render(props.children)` when props change
- Wired `createElement` and `updateElement` through `createElementHook`, replacing the previous single-argument `createControlComponent` call

**`src/domain/map/MapView.tsx`**
- Added `key={\`zoom-${language}\`}` to `<ZoomControl>` to force remount on language change, ensuring `onAdd` re-runs with the current translated `zoomInTitle` and `zoomOutTitle`
- Added `key={\`locate-${language}\`}` to the custom `<Control>` (locate button) for the same reason, with a distinct prefix to avoid the React duplicate-sibling-key bug

**`src/domain/map/__tests__/MapControl.test.tsx`** *(new file)*
- Tests that `createElementHook` is called with `createElement` and `updateElement` as arguments
- Tests that `onAdd` creates the wrapper div and button with correct class names
- Tests that `onAdd` calls `createRoot` on the button and renders initial children
- Tests that `onAdd` stores the React root on the control instance as `_reactRoot`
- Tests that `mousedown`/`dblclick` propagation is stopped
- Tests that the registered click handler invokes `handleClick`
- Tests that `updateElement` calls `_reactRoot.render()` with new children (core language-switch behaviour)
- Tests that `updateElement` does nothing safely when `_reactRoot` is undefined

**`src/domain/map/__tests__/MapView.test.tsx`** *(new file)*
- Tests that `ZoomControl` receives Finnish `zoomInTitle`/`zoomOutTitle` on initial render
- Tests that the locate button renders with a Finnish `aria-label` on initial render
- Tests that `ZoomControl` props update to English and Swedish after language change without page reload
- Tests that the locate button `aria-label` updates to English and Swedish after language change
- Tests that `ZoomControl` is re-rendered when language changes (key-based remount verification)

## How Has This Been Tested?

**Automated:** Two new test files cover the fix — `MapControl.test.tsx` (unit tests for the Leaflet control factory and update mechanism) and `MapView.test.tsx` (integration tests verifying translated props flow through to `ZoomControl` and the locate button after language changes). 

**Manual:** Opened the app in a browser, opened DevTools Console, switched language using the language selector, and immediately ran:
```js
document.querySelector('.leaflet-control-zoom-in').title
document.querySelector('.leaflet-control-zoom-out').title
document.querySelector('.leaflet-control-locate span').getAttribute('aria-label')
```
Confirmed values update to the newly selected language without a page reload.

## Manual Testing Instructions for Reviewers

1. Open the app and navigate to the map view

2. Note the current language (default: Finnish)

3. Open DevTools → Console

4. Switch language to English using the language selector in the header

5. Without refreshing the page, run in the console:

```js
document.querySelector('.leaflet-control-zoom-in').title      // expected: "Zoom in"
document.querySelector('.leaflet-control-zoom-out').title     // expected: "Zoom out"
document.querySelector('.leaflet-control-locate span').getAttribute('aria-label')  // expected: "Show your location"
```

6. Switch to Swedish and repeat — expected: "Zooma in", "Zooma ut", "Visa din plats"

7. Switch back to Finnish — expected: "Lähennä", "Loitonna", "Näytä sijaintisi"

8. Verify that only the control buttons update — the map position, zoom level, and markers remain unchanged after each language switch

9. Optionally test with a screen reader (e.g. NVDA, VoiceOver, Orca) — the announced button names should match the selected language immediately after switching

## Screenshots

https://github.com/user-attachments/assets/10d0af51-88a7-4ce7-bc03-5f4798f22d96


