### PR TITLE
fix: explain asterisk meaning in feedback form (WCAG 3.3.2)

### DIFF
--- a/src/domain/app/AppFeedbackModal.tsx
+++ b/src/domain/app/AppFeedbackModal.tsx
@@ -71,6 +71,7 @@ function AppFeedbackModal({ focusAfterCloseRef, onClose, show }: Props) {
           iconStart={<IconInfoCircle />}
         />
         <Dialog.Content className="outdoor-exercise-map-modal-content">
+          <p>{t("APP.FEEDBACK.REQUIRED_FIELDS")}</p>
           <TextArea
             id="feedback"
             name="feedback"

--- a/src/domain/app/__tests__/AppFeedbackModal.test.tsx
+++ b/src/domain/app/__tests__/AppFeedbackModal.test.tsx
@@ -33,6 +33,24 @@ describe("<AppFeedbackModal />", () => {
     expect(getSubmitButton()).toBeInTheDocument();
   });
 
+  it("renders required fields note explaining the asterisk", () => {
+    render(<AppFeedbackModal show={true} onClose={onClose} />);
+
+    // The full Finnish translation (default language in tests)
+    const note = screen.getByText("Pakolliset kentät on merkitty *-merkillä");
+    expect(note).toBeInTheDocument();
+
+    // Must be a <p> tag and contain the asterisk character
+    expect(note.tagName).toBe("P");
+    expect(note.textContent).toContain("*");
+
+    // The note must appear before the feedback textarea in the DOM
+    const textarea = getFeedbackTextarea();
+    expect(
+      note.compareDocumentPosition(textarea) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("shows email input when checkbox is checked", () => {
     render(<AppFeedbackModal show={true} onClose={onClose} />);
     fireEvent.click(getAnswerCheckbox());
@@ -89,5 +107,23 @@ describe("<AppFeedbackModal />", () => {
 
     // You can check that onClose was called
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("logs error when form is submitted with empty feedback bypassing HTML5 validation", () => {
+    render(<AppFeedbackModal show={true} onClose={onClose} />);
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    // Bypass HTML5 required validation by submitting the form directly
+    const form = document.querySelector("form")!;
+    fireEvent.submit(form);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "User attempted to send feedback without providing feedback",
+    );
+    expect(mockSendFeedback).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
   });
 });

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -30,6 +30,7 @@
     },
     "FEEDBACK": {
       "FEEDBACK": "Feedback",
+      "REQUIRED_FIELDS": "Required fields are marked with *",
       "WANT_ANSWER": "I want a reply to my email",
       "SEND": "Send",
       "EMAIL": "Email"

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -30,6 +30,7 @@
     },
     "FEEDBACK": {
       "FEEDBACK": "Palaute",
+      "REQUIRED_FIELDS": "Pakolliset kentät on merkitty *-merkillä",
       "WANT_ANSWER": "Haluan vastauksen sähköpostiini",
       "SEND": "Lähetä",
       "EMAIL": "Sähköposti"

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -30,6 +30,7 @@
     },
     "FEEDBACK": {
       "FEEDBACK": "Respons",
+      "REQUIRED_FIELDS": "Obligatoriska fält är markerade med *",
       "WANT_ANSWER": "Jag vill ha ett svar till min e–post",
       "SEND": "Skicka",
       "EMAIL": "E–post"


### PR DESCRIPTION
## Description

Add a short explanatory note below the "Give feedback" dialog title to inform users that required fields are marked with an asterisk (`*`). The note is fully translated in Finnish, English, and Swedish.

## Context

WCAG 3.3.2 (Labels or Instructions) requires that sufficient instructions are provided when user input is expected. The feedback form used an asterisk to indicate mandatory fields without explaining its meaning, which may not be clear to all users.

[HUL-68](https://andersinno.atlassian.net/browse/HUL-68)

## Changes

- `src/domain/app/AppFeedbackModal.tsx` — added a `<p>` element at the top of `Dialog.Content` rendering the required fields note
- `src/domain/i18n/locales/fi.json` — added translation key `APP.FEEDBACK.REQUIRED_FIELDS`: `"Pakolliset kentät on merkitty *-merkillä"`
- `src/domain/i18n/locales/en.json` — added translation key `APP.FEEDBACK.REQUIRED_FIELDS`: `"Required fields are marked with *"`
- `src/domain/i18n/locales/sv.json` — added translation key `APP.FEEDBACK.REQUIRED_FIELDS`: `"Obligatoriska fält är markerade med *"`
- `src/domain/app/__tests__/AppFeedbackModal.test.tsx` — added test asserting the required fields note is rendered in the dialog

## How Has This Been Tested?

A unit test was added to `AppFeedbackModal.test.tsx` asserting that the required fields note is rendered when the feedback dialog is open.

## Manual Testing Instructions for Reviewers

1. Open the app and click the **ⓘ** icon in the top-right corner.
2. Select **Give feedback** / **Anna palautetta** / **Ge respons**.
3. Verify that the text explaining the asterisk appears directly below the dialog title, above the feedback textarea.
4. Switch the UI language (fi / en / sv) and confirm the note updates to the correct translation:
   - **fi:** `Pakolliset kentät on merkitty *-merkillä`
   - **en:** `Required fields are marked with *`
   - **sv:** `Obligatoriska fält är markerade med *`

## Screenshots


https://github.com/user-attachments/assets/a3a0f29f-656b-4b61-80f6-578919e93fba


