### PR TITLE
feat: show search result count above results list

### DIFF
--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -63,6 +63,8 @@
     "SHOW_LESS": "Show less",
     "NO_FAVORITES": "No favorites",
     "NO_RESULTS": "No results found",
+    "RESULT_COUNT": "1 result found",
+    "RESULT_COUNT_plural": "{{count}} results found",
     "STATUS": "Condition",
     "UNKNOWN": "Unknown",
     "SATISFACTORY": "Decent",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -63,6 +63,8 @@
     "SHOW_LESS": "Näytä vähemmän",
     "NO_FAVORITES": "Ei suosikkeja",
     "NO_RESULTS": "Ei hakutuloksia",
+    "RESULT_COUNT": "1 hakutulos",
+    "RESULT_COUNT_plural": "{{count}} hakutulosta",
     "STATUS": "Kunto",
     "UNKNOWN": "Tuntematon",
     "SATISFACTORY": "Tyydyttävä",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -63,6 +63,8 @@
     "SHOW_LESS": "Visa mindre",
     "NO_FAVORITES": "Inga favoriter",
     "NO_RESULTS": "Inga sökresultat",
+    "RESULT_COUNT": "1 sökresultat",
+    "RESULT_COUNT_plural": "{{count}} sökresultat",
     "STATUS": "Skick",
     "UNKNOWN": "Okänt",
     "SATISFACTORY": "Hyfsad",

--- a/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
+++ b/src/domain/unit/browser/resultList/UnitBrowserResultList.tsx
@@ -127,6 +127,9 @@ function UnitBrowserResultList({ leafletMap }: Props) {
                 </p>
               ) : (
                 <>
+                  <output className="list-view__results-count">
+                    {t("UNIT_DETAILS.RESULT_COUNT", { count: totalUnits })}
+                  </output>
                   {results.map((unit) => (
                     <UnitListItem key={unit.id} unit={unit} />
                   ))}

--- a/src/domain/unit/browser/resultList/__tests__/UnitBrowserResultList.test.tsx
+++ b/src/domain/unit/browser/resultList/__tests__/UnitBrowserResultList.test.tsx
@@ -231,6 +231,96 @@ describe("<UnitBrowserResultList />", () => {
       localStorage.removeItem("favouriteUnits");
     });
   });
+
+  describe("result count", () => {
+    it("should display plural result count when multiple results exist", async () => {
+      renderComponent();
+      expect(await screen.findByRole("status")).toHaveTextContent(
+        "2 hakutulosta",
+      );
+    });
+
+    it("should display singular result count when one result exists", async () => {
+      renderComponent(
+        {},
+        {
+          unit: {
+            byId: { "53916": units["53916"] },
+            isFetching: false,
+            fetchError: null,
+            all: ["53916"],
+            iceskate: ["53916"],
+            ski: ["53916"],
+            swim: ["53916"],
+            status_ok: [],
+          } as any,
+        },
+      );
+      expect(await screen.findByRole("status")).toHaveTextContent(
+        "1 hakutulos",
+      );
+    });
+
+    it("should not display result count when there are no results", async () => {
+      renderComponent(
+        {},
+        {
+          unit: {
+            byId: {},
+            isFetching: false,
+            fetchError: null,
+            all: [],
+            iceskate: [],
+            ski: [],
+            swim: [],
+            status_ok: [],
+          } as any,
+        },
+      );
+      await screen.findByText("Ei hakutuloksia");
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
+    it("should not display result count while loading", async () => {
+      renderComponent(
+        {},
+        {
+          unit: {
+            byId: units,
+            isFetching: false,
+            fetchError: null,
+            all: Object.keys(units),
+            iceskate: Object.keys(units),
+            ski: Object.keys(units),
+            swim: Object.keys(units),
+            status_ok: [],
+          } as any,
+          search: {
+            isFetching: true,
+            isActive: true,
+            unitResults: [],
+            unitSuggestions: [],
+            addressSuggestions: [],
+          } as any,
+        },
+      );
+      expect(
+        document.querySelector(".list-view__results-count"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should display total count even when only one page is visible", async () => {
+      // UNIT_BATCH_SIZE is mocked to 1, so only 1 unit is shown initially
+      // but totalUnits should still be 2
+      renderComponent();
+      expect(await screen.findByRole("status")).toHaveTextContent(
+        "2 hakutulosta",
+      );
+      expect(
+        screen.queryByText("Mustavuoren latu 2,1 km"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe("<UnitBrowserResultListSort />", () => {

--- a/src/domain/unit/browser/resultList/_unitBrowserResultList.scss
+++ b/src/domain/unit/browser/resultList/_unitBrowserResultList.scss
@@ -13,6 +13,12 @@
       background-color: var(--color-white);
       padding: $gap;
       min-height: 128px;
+
+      .list-view__results-count {
+        margin: 0 0 var(--spacing-s) 0;
+        font-size: var(--fontsize-body-m);
+        font-weight: bold;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Display the total number of matching search results at the top of the results list. Previously users had no way of knowing how many venues matched their search or how many pages of results existed.

## Context

Users searching for sports venues were unaware of the total number of results returned, making it difficult to judge whether to paginate further or refine their search. This change adds a visible and screen-reader-accessible result count above the results list.

[HUL-69](https://andersinno.atlassian.net/browse/HUL-69)

## Changes

- `src/domain/unit/browser/resultList/UnitBrowserResultList.tsx` — Added a `<p role="status">` element above the results list showing the total result count.
- `src/domain/unit/browser/resultList/_unitBrowserResultList.scss` — Added `.list-view__results-count` style rule (bold, body font size, bottom margin).
- `src/domain/i18n/locales/en.json` — Added `RESULT_COUNT` / `RESULT_COUNT_plural` translation keys.
- `src/domain/i18n/locales/fi.json` — Added `RESULT_COUNT` / `RESULT_COUNT_plural` translation keys.
- `src/domain/i18n/locales/sv.json` — Added `RESULT_COUNT` / `RESULT_COUNT_plural` translation keys.
- `src/domain/unit/browser/resultList/__tests__/UnitBrowserResultList.test.tsx` — Added tests covering plural count, singular count, empty when no results, empty while loading, and total count shown when only one page is visible.

## How Has This Been Tested?

**Automated:** new unit tests added to the existing `UnitBrowserResultList` test suite covering all branches of the new count element.

**Manual:** Verified in the browser with `REACT_APP_BYPASS_SEASON_FILTER=true`. Searched for skiing venues and confirmed the count appears above the list, reflects the total across all pages, and updates correctly when filters change. Verified with Orca that the result count is readable when navigating the results list using arrow keys.

## Manual Testing Instructions for Reviewers

1. Select a sport (e.g. Skiing) — a result count should appear above the list, e.g. **"42 hakutulosta"** (fi) / **"42 results found"** (en)
2. Click **Show more** — the count should remain at the total, not decrease to the currently visible page size
3. Apply a filter that yields no results — the count should disappear and the existing "No results found" message should show
4. Switch the UI language (fi/sv/en) — the count string should translate accordingly
5. Test with a screen reader (e.g. VoiceOver, NVDA or Orca) — navigate to the results list using arrow keys to read the result count

## Screenshots


https://github.com/user-attachments/assets/6916390a-1d11-45c9-b832-c9dc271e7ce0


