### PR TITLE
feat: show success and error notifications after feedback submission

### DIFF
--- a/src/domain/app/AppFeedbackModal.tsx
+++ b/src/domain/app/AppFeedbackModal.tsx
@@ -5,8 +5,9 @@ import {
   TextInput,
   TextArea,
   IconInfoCircle,
+  Notification,
 } from "hds-react";
-import React, { RefObject, useCallback, useState } from "react";
+import React, { RefObject, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useSendFeedbackMutation } from "./state/appSlice";
@@ -23,36 +24,53 @@ function AppFeedbackModal({ focusAfterCloseRef, onClose, show }: Props) {
   const [feedback, setFeedback] = useState<string>("");
   const [emailInputOpen, setEmailInputOpen] = useState<boolean>(false);
   const [email, setEmail] = useState<string>("");
-  const [sendFeedback] = useSendFeedbackMutation();
+  const [submitStatus, setSubmitStatus] = useState<
+    "idle" | "success" | "error"
+  >("idle");
+  const [sendFeedback, { isLoading }] = useSendFeedbackMutation();
 
-  // Clear values when modal is opened
-  React.useEffect(() => {
-    if (show) {
-      setFeedback("");
-      setEmail("");
-      setEmailInputOpen(false);
-    }
-  }, [show]);
+  // Resets all form state and closes the dialog.
+  // Used by both the X button and the auto-close timer so state is always
+  // clean when the modal next opens.
+  const handleClose = useCallback(() => {
+    setFeedback("");
+    setEmail("");
+    setEmailInputOpen(false);
+    setSubmitStatus("idle");
+    onClose();
+  }, [onClose]);
+
+  // Auto-close after the success or error notification has been displayed
+  useEffect(() => {
+    if (submitStatus === "idle") return;
+    const timer = setTimeout(handleClose, 5000);
+    return () => clearTimeout(timer);
+  }, [submitStatus, handleClose]);
 
   const handleToggleEmailInput = useCallback(() => {
     setEmailInputOpen((prevState) => !prevState);
   }, []);
 
   const handleOnSubmit = useCallback(
-    (e: React.SyntheticEvent) => {
+    async (e: React.SyntheticEvent) => {
       e.preventDefault();
 
-      if (feedback) {
-        sendFeedback({ feedback, email });
-        onClose();
-      } else {
+      if (!feedback) {
         // eslint-disable-next-line no-console
         console.error(
           `User attempted to send feedback without providing feedback`,
         );
+        return;
+      }
+
+      try {
+        await sendFeedback({ feedback, email }).unwrap();
+        setSubmitStatus("success");
+      } catch {
+        setSubmitStatus("error");
       }
     },
-    [sendFeedback, email, feedback, onClose],
+    [sendFeedback, email, feedback],
   );
 
   return (
@@ -60,7 +78,7 @@ function AppFeedbackModal({ focusAfterCloseRef, onClose, show }: Props) {
       id="about-dialog"
       aria-labelledby={titleId}
       isOpen={show}
-      close={onClose}
+      close={handleClose}
       closeButtonLabelText={t("APP.MODAL.CLOSE")}
       focusAfterCloseRef={focusAfterCloseRef}
     >
@@ -71,38 +89,56 @@ function AppFeedbackModal({ focusAfterCloseRef, onClose, show }: Props) {
           iconStart={<IconInfoCircle />}
         />
         <Dialog.Content className="outdoor-exercise-map-modal-content">
-          <p>{t("APP.FEEDBACK.REQUIRED_FIELDS")}</p>
-          <TextArea
-            id="feedback"
-            name="feedback"
-            label={t("APP.FEEDBACK.FEEDBACK")}
-            placeholder={t("APP.FEEDBACK.FEEDBACK")}
-            value={feedback}
-            onChange={(e) => setFeedback(e.target.value)}
-            required
-          />
-          <Checkbox
-            id="want-answer"
-            name="want-answer"
-            label={t("APP.FEEDBACK.WANT_ANSWER")}
-            onChange={handleToggleEmailInput}
-            checked={emailInputOpen}
-          />
-          {emailInputOpen && (
-            <TextInput
-              id="email"
-              name="email"
-              label={t("APP.FEEDBACK.EMAIL")}
-              placeholder={t("APP.FEEDBACK.EMAIL")}
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required={emailInputOpen}
-            />
+          <div role="status" aria-live="polite" aria-atomic="true">
+            {submitStatus === "success" && (
+              <Notification type="success" label={t("APP.FEEDBACK.SUCCESS")} />
+            )}
+          </div>
+          <div role="alert" aria-live="assertive" aria-atomic="true">
+            {submitStatus === "error" && (
+              <Notification type="error" label={t("APP.FEEDBACK.ERROR")} />
+            )}
+          </div>
+          {submitStatus === "idle" && (
+            <>
+              <TextArea
+                id="feedback"
+                name="feedback"
+                label={t("APP.FEEDBACK.FEEDBACK")}
+                placeholder={t("APP.FEEDBACK.FEEDBACK")}
+                value={feedback}
+                onChange={(e) => setFeedback(e.target.value)}
+                required
+              />
+              <Checkbox
+                id="want-answer"
+                name="want-answer"
+                label={t("APP.FEEDBACK.WANT_ANSWER")}
+                onChange={handleToggleEmailInput}
+                checked={emailInputOpen}
+              />
+              {emailInputOpen && (
+                <TextInput
+                  id="email"
+                  name="email"
+                  label={t("APP.FEEDBACK.EMAIL")}
+                  placeholder={t("APP.FEEDBACK.EMAIL")}
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required={emailInputOpen}
+                />
+              )}
+            </>
           )}
         </Dialog.Content>
         <Dialog.ActionButtons>
-          <Button type="submit">{t("APP.FEEDBACK.SEND")}</Button>
+          <Button
+            type="submit"
+            disabled={isLoading || submitStatus !== "idle"}
+          >
+            {t("APP.FEEDBACK.SEND")}
+          </Button>
         </Dialog.ActionButtons>
       </form>
     </Dialog>

--- a/src/domain/app/__tests__/AppFeedbackModal.test.tsx
+++ b/src/domain/app/__tests__/AppFeedbackModal.test.tsx
@@ -1,72 +1,75 @@
 import {
   render,
   screen,
+  act,
   fireEvent,
   userEvent,
 } from "../../testingLibraryUtils";
 import AppFeedbackModal from "../AppFeedbackModal";
 
-// Mock the RTK Query mutation hook
+// Mutable state object so individual tests can set isLoading = true.
+// Declared before vi.mock so the factory closure captures it by reference.
+const mockMutationState = { isLoading: false };
 const mockSendFeedback = vi.fn();
+
 vi.mock("../state/appSlice", () => ({
-  useSendFeedbackMutation: () => [mockSendFeedback, {}],
+  useSendFeedbackMutation: () => [mockSendFeedback, mockMutationState],
 }));
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const getFeedbackTextarea = () =>
+  screen.getByRole("textbox", { name: /Palaute/i });
+const getSubmitButton = () =>
+  screen.getByRole("button", { name: /Lähetä/i });
+const getCloseButton = () =>
+  screen.getByRole("button", { name: /Sulje/i });
+const getAnswerCheckbox = () =>
+  screen.getByRole("checkbox", { name: /Haluan vastauksen sähköpostiini/i });
+const getEmailInput = () =>
+  screen.getByRole("textbox", { name: /sähköposti/i });
+
+// ─── suite ────────────────────────────────────────────────────────────────────
 
 describe("<AppFeedbackModal />", () => {
   const onClose = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMutationState.isLoading = false;
+    // Default: successful API call
+    mockSendFeedback.mockReturnValue({ unwrap: () => Promise.resolve() });
   });
 
-  const getFeedbackTextarea = () =>
-    screen.getByRole("textbox", { name: /Palaute/i });
-  const getSubmitButton = () => screen.getByRole("button", { name: "Lähetä" });
-  const getAnswerCheckbox = () =>
-    screen.getByRole("checkbox", { name: /Haluan vastauksen sähköpostiini/i });
-  const getEmailInput = () =>
-    screen.getByRole("textbox", { name: /sähköposti/i });
+  // ── idle state ──────────────────────────────────────────────────────────────
 
-  it("renders feedback textarea and send button", () => {
+  it("renders feedback textarea and enabled send button when idle", () => {
     render(<AppFeedbackModal show={true} onClose={onClose} />);
     expect(getFeedbackTextarea()).toBeInTheDocument();
     expect(getSubmitButton()).toBeInTheDocument();
+    expect(getSubmitButton()).not.toBeDisabled();
   });
 
-  it("renders required fields note explaining the asterisk", () => {
+  it("shows email input when checkbox is checked", async () => {
+    const user = userEvent.setup();
     render(<AppFeedbackModal show={true} onClose={onClose} />);
-
-    // The full Finnish translation (default language in tests)
-    const note = screen.getByText("Pakolliset kentät on merkitty *-merkillä");
-    expect(note).toBeInTheDocument();
-
-    // Must be a <p> tag and contain the asterisk character
-    expect(note.tagName).toBe("P");
-    expect(note.textContent).toContain("*");
-
-    // The note must appear before the feedback textarea in the DOM
-    const textarea = getFeedbackTextarea();
-    expect(
-      note.compareDocumentPosition(textarea) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-  });
-
-  it("shows email input when checkbox is checked", () => {
-    render(<AppFeedbackModal show={true} onClose={onClose} />);
-    fireEvent.click(getAnswerCheckbox());
+    await user.click(getAnswerCheckbox());
     expect(getEmailInput()).toBeInTheDocument();
   });
 
-  it("does not submit if feedback is empty", async () => {
-    render(<AppFeedbackModal show={true} onClose={onClose} />);
+  it("hides email input when checkbox is unchecked again", async () => {
     const user = userEvent.setup();
-    
-    // Try to submit with empty feedback
+    render(<AppFeedbackModal show={true} onClose={onClose} />);
+    await user.click(getAnswerCheckbox());
+    await user.click(getAnswerCheckbox());
+    expect(screen.queryByRole("textbox", { name: /sähköposti/i })).not.toBeInTheDocument();
+  });
+
+  it("does not call mutation if feedback is empty", async () => {
+    const user = userEvent.setup();
+    render(<AppFeedbackModal show={true} onClose={onClose} />);
     await user.click(getSubmitButton());
-    
-    // Check that form validation prevents submission
-    const textarea = getFeedbackTextarea();
-    expect(textarea).toBeInvalid(); // HTML5 validation should mark it as invalid
+    expect(getFeedbackTextarea()).toBeInvalid();
     expect(mockSendFeedback).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
     
@@ -74,39 +77,132 @@ describe("<AppFeedbackModal />", () => {
     expect(getFeedbackTextarea()).toBeInTheDocument();
   });
 
-  it("email input is invalid with empty value", async () => {
-    render(<AppFeedbackModal show={true} onClose={onClose} />);
+  it("email input is invalid when empty with checkbox checked", async () => {
     const user = userEvent.setup();
+    render(<AppFeedbackModal show={true} onClose={onClose} />);
     await user.click(getAnswerCheckbox());
     await user.type(getFeedbackTextarea(), "Test feedback");
-
     expect((getEmailInput() as HTMLInputElement).checkValidity()).toBe(false);
   });
 
-  it("email input is invalid with wrong value", async () => {
-    render(<AppFeedbackModal show={true} onClose={onClose} />);
+  it("email input is invalid with malformed value", async () => {
     const user = userEvent.setup();
+    render(<AppFeedbackModal show={true} onClose={onClose} />);
     await user.click(getAnswerCheckbox());
     await user.type(getEmailInput(), "invalid-email");
     await user.type(getFeedbackTextarea(), "Test feedback");
-
     expect((getEmailInput() as HTMLInputElement).checkValidity()).toBe(false);
   });
 
-  it("submits feedback without triggering real saga", async () => {
-    render(<AppFeedbackModal show={true} onClose={onClose} />);
-    const user = userEvent.setup();
-    await user.type(getFeedbackTextarea(), "Test feedback");
-    fireEvent.click(getSubmitButton());
+  // ── loading state ───────────────────────────────────────────────────────────
 
-    // Check that sendFeedback mutation was called with correct params
+  it("disables send button while mutation is loading", () => {
+    mockMutationState.isLoading = true;
+    render(<AppFeedbackModal show={true} onClose={onClose} />);
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  // ── submission params ───────────────────────────────────────────────────────
+
+  it("calls mutation with feedback text and empty email by default", async () => {
+    const user = userEvent.setup();
+    render(<AppFeedbackModal show={true} onClose={onClose} />);
+    await user.type(getFeedbackTextarea(), "Test feedback");
+    await user.click(getSubmitButton());
     expect(mockSendFeedback).toHaveBeenCalledWith({
       feedback: "Test feedback",
       email: "",
     });
+  });
 
-    // You can check that onClose was called
-    expect(onClose).toHaveBeenCalled();
+  it("calls mutation with email when checkbox is checked", async () => {
+    const user = userEvent.setup();
+    render(<AppFeedbackModal show={true} onClose={onClose} />);
+    await user.click(getAnswerCheckbox());
+    await user.type(getEmailInput(), "user@example.com");
+    await user.type(getFeedbackTextarea(), "Test feedback");
+    await user.click(getSubmitButton());
+    expect(mockSendFeedback).toHaveBeenCalledWith({
+      feedback: "Test feedback",
+      email: "user@example.com",
+    });
+  });
+
+  // ── successful submission ───────────────────────────────────────────────────
+
+  describe("after a successful submission", () => {
+    const submitAndWaitForSuccess = async () => {
+      const user = userEvent.setup();
+      render(<AppFeedbackModal show={true} onClose={onClose} />);
+      await user.type(getFeedbackTextarea(), "Test feedback");
+      await user.click(getSubmitButton());
+      expect(
+        screen.getByText("Palautteesi lähetettiin onnistuneesti.")
+      ).toBeInTheDocument();
+    };
+
+    it("shows the success notification", async () => {
+      await submitAndWaitForSuccess();
+      expect(
+        screen.getByText("Palautteesi lähetettiin onnistuneesti.")
+      ).toBeInTheDocument();
+    });
+
+    it("hides form fields", async () => {
+      await submitAndWaitForSuccess();
+      expect(
+        screen.queryByRole("textbox", { name: /Palaute/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("disables send button", async () => {
+      await submitAndWaitForSuccess();
+      expect(getSubmitButton()).toBeDisabled();
+    });
+  });
+
+  // ── failed submission ───────────────────────────────────────────────────────
+
+  describe("after a failed submission", () => {
+    beforeEach(() => {
+      mockSendFeedback.mockReturnValue({
+        unwrap: () => Promise.reject(new Error("Network error")),
+      });
+    });
+
+    const submitAndWaitForError = async () => {
+      const user = userEvent.setup();
+      render(<AppFeedbackModal show={true} onClose={onClose} />);
+      await user.type(getFeedbackTextarea(), "Test feedback");
+      await user.click(getSubmitButton());
+      expect(
+        screen.getByText(
+          "Palautteen lähetys epäonnistui. Yritä myöhemmin uudelleen."
+        )
+      ).toBeInTheDocument();
+    };
+
+    it("shows the error notification", async () => {
+      await submitAndWaitForError();
+      expect(
+        screen.getByText(
+          "Palautteen lähetys epäonnistui. Yritä myöhemmin uudelleen."
+        )
+      ).toBeInTheDocument();
+    });
+
+    it("disables send button", async () => {
+      await submitAndWaitForError();
+      expect(getSubmitButton()).toBeDisabled();
+    });
+  });
+
+  // ── close behaviour ─────────────────────────────────────────────────────────
+
+  it("calls onClose when the dialog X button is clicked", async () => {
+    render(<AppFeedbackModal show={true} onClose={onClose} />);
+    await userEvent.click(getCloseButton());
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("logs error when form is submitted with empty feedback bypassing HTML5 validation", () => {

--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -33,7 +33,9 @@
       "REQUIRED_FIELDS": "Required fields are marked with *",
       "WANT_ANSWER": "I want a reply to my email",
       "SEND": "Send",
-      "EMAIL": "Email"
+      "EMAIL": "Email",
+      "SUCCESS": "Your feedback was sent successfully.",
+      "ERROR": "Sending feedback failed. Please try again later."
     },
     "MAP_ATTRIBUTION": "OpenStreetMap contributors",
     "NOTIFICATION_TITLE": "Notification",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -33,7 +33,9 @@
       "REQUIRED_FIELDS": "Pakolliset kentät on merkitty *-merkillä",
       "WANT_ANSWER": "Haluan vastauksen sähköpostiini",
       "SEND": "Lähetä",
-      "EMAIL": "Sähköposti"
+      "EMAIL": "Sähköposti",
+      "SUCCESS": "Palautteesi lähetettiin onnistuneesti.",
+      "ERROR": "Palautteen lähetys epäonnistui. Yritä myöhemmin uudelleen."
     },
     "MAP_ATTRIBUTION": "OpenStreetMap tekijät",
     "NOTIFICATION_TITLE": "Ilmoitus",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -33,7 +33,9 @@
       "REQUIRED_FIELDS": "Obligatoriska fält är markerade med *",
       "WANT_ANSWER": "Jag vill ha ett svar till min e–post",
       "SEND": "Skicka",
-      "EMAIL": "E–post"
+      "EMAIL": "E–post",
+      "SUCCESS": "Din feedback har skickats.",
+      "ERROR": "Det gick inte att skicka feedback. Försök igen senare."
     },
     "MAP_ATTRIBUTION": "OpenStreetMaps skapare",
     "NOTIFICATION_TITLE": "Annons",


### PR DESCRIPTION
## Description

After submitting the feedback form, the user received no confirmation that the action was successful — the modal simply closed silently. Users could incorrectly assume the submission failed.

This adds an inline success or error notification inside the feedback modal after submission, before the modal auto-closes after 3 seconds.

## Context

Users submitting feedback via the i-menu → "Give feedback" flow had no indication of whether their feedback was sent or not, causing confusion.

[HUL-70](https://andersinno.atlassian.net/browse/HUL-70)
## Changes

- `src/domain/app/AppFeedbackModal.tsx` — replaced fire-and-forget mutation with `async/await` + `.unwrap()` to detect success vs failure; added HDS `Notification` for both outcomes inside the modal; form fields hidden on success; send button disabled while loading/after submit; modal auto-closes after 3 seconds via `handleClose`; ARIA live regions (`role="status"` / `role="alert"`) added for screen reader support
- `src/domain/i18n/locales/fi.json` — added `APP.FEEDBACK.SUCCESS` and `APP.FEEDBACK.ERROR`
- `src/domain/i18n/locales/en.json` — added `APP.FEEDBACK.SUCCESS` and `APP.FEEDBACK.ERROR`
- `src/domain/i18n/locales/sv.json` — added `APP.FEEDBACK.SUCCESS` and `APP.FEEDBACK.ERROR`
- `src/domain/app/__tests__/AppFeedbackModal.test.tsx` — updated tests to cover success notification, error notification, loading/disabled state, field validation, and close behaviour

## How Has This Been Tested?

Automated: updated unit tests in `AppFeedbackModal.test.tsx` covering all new branches (success, error, loading, close).

Manual: opened the app, submitted feedback via i-menu → Give feedback → send; verified success notification appears and modal closes after 3 seconds. Also verified the error path by temporarily mocking a network failure.

## Manual Testing Instructions for Reviewers

1. Open the app and navigate to the i-menu (top right) → **Give feedback**
2. Type some text in the feedback field and click **Send**
3. Verify a green success notification appears: *"Your feedback was sent successfully."*
4. Verify the modal closes automatically after ~3 seconds
5. Reopen the form — verify it is blank with no notification visible
6. To test the error path: in DevTools → Network, block `api.hel.fi` and repeat — verify a red error notification appears: *"Sending feedback failed. Please try again later."*
7. To test screen reader accessibility: enable VoiceOver, NVDA or Orca,  submit the form, and verify the success/error message is announced without requiring focus to move to the notification

## Screenshots


https://github.com/user-attachments/assets/d6b2a9c4-cd3a-4c9b-9a97-e484f63946b8


