### PR TITLE
fix(a11y): remove redundant aria-expanded from toggle buttons

### DIFF
--- a/src/domain/app/AppHeader.tsx
+++ b/src/domain/app/AppHeader.tsx
@@ -166,7 +166,6 @@ function ApplicationHeader({
           {isMobile && (
             <HeaderButton
               id="action-bar-map-toggle"
-              aria-expanded={isExpanded}
               aria-controls={panelId}
               icon={<IconMap />}
               label={

--- a/src/domain/home/HomeContainer.tsx
+++ b/src/domain/home/HomeContainer.tsx
@@ -111,7 +111,6 @@ function MapLayout({
         {!isMobile && (
           <TextRevealButton
             aria-controls={PANEL_ID}
-            aria-expanded={isExpanded}
             className={className("map-collapse-button", {
               "panel-hidden": !isExpanded,
             })}


### PR DESCRIPTION
## Description

Remove the `aria-expanded` attribute from the mobile close/open map button and the desktop hide sidebar button.

## Context

The `aria-expanded` attribute was duplicating state information already conveyed by the accessible name of each button (the label text changes to reflect the current state). Having both caused redundant announcements for screen reader users, making it harder to understand the button's behaviour without visual context.

[HUL-71](https://andersinno.atlassian.net/browse/HUL-71)

## Changes

- `src/domain/app/AppHeader.tsx` — removed `aria-expanded` from the mobile map toggle `HeaderButton`
- `src/domain/home/HomeContainer.tsx` — removed `aria-expanded` from the desktop hide sidebar `TextRevealButton`

## How Has This Been Tested?

Existing unit tests pass. The `HeaderButton` unit test covering `aria-expanded` prop passthrough is unaffected as it tests the component in isolation, not the removed usage.

## Manual Testing Instructions for Reviewers

1. **Mobile view** — open the map toggle button and verify the screen reader announces only the button label (e.g. "Open map" / "Close map") without a redundant expanded/collapsed state.
2. **Desktop view** — click the hide/show sidebar button and verify the screen reader announces only the button label ("Hide sidebar" / "Show sidebar") without a redundant state announcement.
3. Confirm the buttons still toggle correctly and `aria-controls` remains functional.

## Screenshots


https://github.com/user-attachments/assets/446fef63-9225-4650-b417-b03f308ca090

