### PR TITLE
fix(a11y): remove aria-haspopup from filter buttons (WCAG 1.3.1)

### DIFF
--- a/src/domain/unit/browser/filter/UnitBrowserFilter.tsx
+++ b/src/domain/unit/browser/filter/UnitBrowserFilter.tsx
@@ -80,7 +80,6 @@ export function FilterOption({
         filter={filter}
         onAction={onToggle}
         isActive={isActive}
-        aria-haspopup="true"
         aria-controls={menuId}
         id={controlId}
       />

--- a/src/domain/unit/browser/filter/UnitBrowserFilterButton.tsx
+++ b/src/domain/unit/browser/filter/UnitBrowserFilterButton.tsx
@@ -17,7 +17,6 @@ type Props = {
       | React.KeyboardEvent<HTMLElement>,
   ) => void;
   id?: string;
-  "aria-haspopup"?: boolean | "grid" | "listbox" | "menu" | "tree" | "dialog";
   "aria-controls"?: string;
   "aria-expanded"?: boolean;
   "aria-label"?: string;

--- a/src/domain/unit/browser/filter/UnitBrowserFilterLabelButton.tsx
+++ b/src/domain/unit/browser/filter/UnitBrowserFilterLabelButton.tsx
@@ -58,7 +58,7 @@ function UnitBrowserFilterLabelButton({
         message={buttonMessage}
         aria-label={[buttonMessage, labelMessage].join(", ")}
         aria-expanded={isActive}
-        {...pick(rest, ["aria-haspopup", "aria-controls", "id"])}
+        {...pick(rest, ["aria-controls", "id"])}
       />
     </div>
   );


### PR DESCRIPTION
## Description

Remove `aria-haspopup="true"` from the Choose sport, Choose condition, and Outdoor services filter buttons.

## Context

According to current WCAG 1.3.1 guidelines, `aria-haspopup` is no longer necessary for assistive devices — the needed information is already conveyed by other attributes on the component (eg. `aria-controls`). The attribute was identified as redundant.

[HUL-72](https://andersinno.atlassian.net/browse/HUL-72)

## Changes

- `src/domain/unit/browser/filter/UnitBrowserFilter.tsx` — removed `aria-haspopup="true"` from the filter label button JSX
- `src/domain/unit/browser/filter/UnitBrowserFilterButton.tsx` — removed `"aria-haspopup"` from the `Props` type definition
- `src/domain/unit/browser/filter/UnitBrowserFilterLabelButton.tsx` — removed `"aria-haspopup"` from the forwarded props (`pick`)

## How Has This Been Tested?

No existing tests referenced `aria-haspopup`, so no test changes were required.

## Manual Testing Instructions for Reviewers

1. Open the map view.
2. Activate a screen reader (e.g. NVDA, VoiceOver, Orca , etc).
3. Tab to and activate each of the three filter buttons: **Choose sport**, **Choose condition**, **Outdoor services**.
4. Confirm the screen reader announces the expanded/collapsed state correctly .
## Screenshots


https://github.com/user-attachments/assets/0b52670d-667a-4bee-9add-0d7a290cfdc6


