### PR TITLE
fix: clarify route guide link text to reference HSL route guide expli…

### DIFF
--- a/src/domain/i18n/locales/en.json
+++ b/src/domain/i18n/locales/en.json
@@ -129,7 +129,7 @@
     "SKIING_TECHNIQUE_TRADITIONAL": "Classic",
     "TEMPERATURE": "Temperature",
     "LINKS": "Links",
-    "GET_ROUTE": "Get route to here",
+    "GET_ROUTE": "Directions in the HSL route guide",
     "EXTRA_INFO": "Information on swimming water quality",
     "NOTICE": "Notice",
     "WATER_TEMPERATURE": "Water temperature",

--- a/src/domain/i18n/locales/fi.json
+++ b/src/domain/i18n/locales/fi.json
@@ -130,7 +130,7 @@
     "SKIING_TECHNIQUE_TRADITIONAL": "Perinteinen",
     "TEMPERATURE": "Lämpötila",
     "LINKS": "Linkit",
-    "GET_ROUTE": "Hae reitti tänne",
+    "GET_ROUTE": "Reittiohjeet HSL:n reittioppaassa",
     "EXTRA_INFO": "Katso tietoa uimaveden laadusta",
     "NOTICE": "Tiedote",
     "WATER_TEMPERATURE": "Veden lämpötila",

--- a/src/domain/i18n/locales/sv.json
+++ b/src/domain/i18n/locales/sv.json
@@ -129,7 +129,7 @@
     "SKIING_TECHNIQUE_TRADITIONAL": "Klassisk",
     "TEMPERATURE": "Temperatur",
     "LINKS": "Länkar",
-    "GET_ROUTE": "Väg hit",
+    "GET_ROUTE": "Vägbeskrivning i HRT:s reseplaneraren",
     "EXTRA_INFO": "Se information om badvattnets kvalitet",
     "NOTICE": "Meddelande",
     "WATER_TEMPERATURE": "Vattnets temperatur",


### PR DESCRIPTION
## Description

Update the route guide link label to clearly communicate that it opens the HSL route guide, instead of the vague "Hae reitti tänne" / "Get route to here" wording.

## Context

The link to the HSL route guide was unclear to users — both visually and in terms of accessibility. The new labels name the destination service explicitly in all three supported languages.

[HUL-73](https://andersinno.atlassian.net/browse/HUL-73)

## Changes

- `src/domain/i18n/locales/fi.json` — `GET_ROUTE`: "Hae reitti tänne" → "Reittiohjeet HSL:n reittioppaassa"
- `src/domain/i18n/locales/en.json` — `GET_ROUTE`: "Get route to here" → "Directions in the HSL route guide"
- `src/domain/i18n/locales/sv.json` — `GET_ROUTE`: "Väg hit" → "Vägbeskrivning i HRT:s reseplaneraren"

## How Has This Been Tested?

Translation-only change; no automated tests required. Verified manually by switching UI language and checking the route guide link label on a unit detail page.

## Manual Testing Instructions for Reviewers

1. Open any sports facility detail page that has a route guide link.
2. Verify the link reads "Reittiohjeet HSL:n reittioppaassa" in Finnish, "Directions in the HSL route guide" in English, and "Vägbeskrivning i HRT:s reseplaneraren" in Swedish.
3. Inspect the link element and confirm the accessible name reflects the updated text.

## Screenshots


https://github.com/user-attachments/assets/5ea30a4b-db15-4e7e-94ce-0dde257f1d19


